### PR TITLE
Fixes the issues and project links in the project

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,10 +1,12 @@
 {
   "name": "puppetlabs-splunk_hec",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": "Puppet, Inc.",
   "summary": "Puppet report processor using Splunk HEC",
   "license": "Apache-2.0",
-  "source": "https://github.com/puppetlabs/splunk_hec",
+  "source": "https://github.com/puppetlabs/puppetlabs-splunk_hec",
+  "project_page": "https://github.com/puppetlabs/puppetlabs-splunk_hec",
+  "issues_url": "https://github.com/puppetlabs/puppetlabs-splunk_hec/issues",
   "dependencies": [
 
   ],


### PR DESCRIPTION
RENAMES project links to puppetlabs-splunk_hec to conform with
internal naming guides for repos