### PR TITLE
(PIE-66) Adds store support

### DIFF
--- a/lib/puppet/application/splunk_hec.rb
+++ b/lib/puppet/application/splunk_hec.rb
@@ -16,6 +16,8 @@ class Puppet::Application::Splunk_hec < Puppet::Application
 
   option('--pe_metrics')
 
+  option('--saved_report')
+
   def get_name(servername)
     if servername.to_s == '127-0-0-1'
       name = Puppet[:certname].to_s
@@ -46,6 +48,10 @@ class Puppet::Application::Splunk_hec < Puppet::Application
     end
   end
 
+  def upload_report(data, sourcetype)
+    submit_request(data)
+  end
+
   def main
     data = JSON.parse(STDIN.read)
 
@@ -54,6 +60,11 @@ class Puppet::Application::Splunk_hec < Puppet::Application
     if options[:pe_metrics]
       send_pe_metrics(data, sourcetype)
     end
+    
+    if options[:saved_report]
+      upload_report(data, sourcetype)
+    end
+
   end
 end
 

--- a/lib/puppet/reports/splunk_hec.rb
+++ b/lib/puppet/reports/splunk_hec.rb
@@ -55,6 +55,10 @@ Puppet::Reports.register_report(:splunk_hec) do
 
     Puppet.info "Submitting report to Splunk at #{splunk_url}"
     submit_request event
+    if record_event
+      store_event event
+    end
+
   rescue StandardError => e
     Puppet.err "Could not send report to Splunk: #{e}\n#{e.backtrace}"
   end

--- a/lib/puppet/util/splunk_hec.rb
+++ b/lib/puppet/util/splunk_hec.rb
@@ -54,7 +54,7 @@ module Puppet::Util::Splunk_hec
 
   def store_event(event)
     host = event['host']
-    epoch = event['time']
+    epoch = event['time'].to_f
 
     timestamp = Time.at(epoch).to_datetime
 
@@ -89,7 +89,7 @@ module Puppet::Util::Splunk_hec
   end
 
   def record_event
-    if settings['record_event'] == 'True'
+    if settings['record_event'] == 'true'
       result = true
     else
       result = false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@ class splunk_hec (
   String $token,
   Array $collect_facts = ["dmi","disks","partitions","processors","networking"],
   Boolean $enable_reports = false,
+  Boolean $record_event = false,
   String $reports = "puppetdb,splunk_hec",
   Optional[String] $pe_console = undef,
   Optional[Integer] $timeout = undef,

--- a/templates/splunk_hec.yaml.epp
+++ b/templates/splunk_hec.yaml.epp
@@ -15,3 +15,6 @@
 <% if $splunk_hec::ssl_ca { -%>
 "ssl_ca" : "<%= $splunk_hec::ssl_ca %>"
 <% } -%>
+<% if $splunk_hec::record_event { -%>
+"record_event" : "<%= $splunk_hec::record_event %>"
+<% } -%>


### PR DESCRIPTION
This enables the splunk_hec plugin's report processor to save reports to disk along with adding the faces ability to upload them to splunk.

Essentially this lets us replay a HEC report submission whenever we want, for both testing the splunk demos and validating we are creating the properly formatted events to send to splunk.