### PR TITLE
PIE-67 Support multiple indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,15 @@ nodes:
 See the `plans/` directory for working examples of apply and result usage.
 
 
+Advanced Splunk Configuration Options
+-----------
+The splunk_hec class and data processors support setting individual HEC tokens and URLs for each type of data supported. This is designed so users can specify a different HEC token if they wish their Puppet Reports are stored in a different index than their Facts, etc. Making changes here assumes you know how to use indexs and update the advanced search macros in Splunk so the Report Viewer can load data from those indexes.
+
+- Summary Reports: Corresponds to puppet:summary in the Puppet Report Viewer, use `token_summary` and `url_summary` parameter or value in splunk_hec.yaml
+- Fact Data: Corresponds to puppet:facts in the Puppet Report Viewer, use `token_facts` and `url_facts` parameter or value in splunk_hec.yaml
+- PE Metrics: Corresponds to puppet:metrics in the Puppet Report Viewer, use `token_metrics` and `url_metrics` parameter or value in splunk_hec.yaml (at this time, collecting PE Metrics is not supported, but the sourcetype exists in the app)
+
+Different URLs only need to be specified if different HEC systems entirely are being used. If one is using one collecter server, but multiple HECs, just provide the `url` setting as before, and specify each sourcetype's corresponding HEC token.
 
 
 Known Issues

--- a/lib/puppet/indirector/facts/splunk_hec.rb
+++ b/lib/puppet/indirector/facts/splunk_hec.rb
@@ -47,7 +47,7 @@ class Puppet::Node::Facts::Splunk_hec < Puppet::Node::Facts::Puppetdb
           'event' => facts,
         }
 
-        Puppet.info "Submitting facts to Splunk at #{splunk_url}"
+        Puppet.info "Submitting facts to Splunk at #{get_splunk_url('facts')}"
         submit_request event
       rescue StandardError => e
         Puppet.err "Could not send facts to Splunk: #{e}\n#{e.backtrace}"

--- a/lib/puppet/reports/splunk_hec.rb
+++ b/lib/puppet/reports/splunk_hec.rb
@@ -53,7 +53,7 @@ Puppet::Reports.register_report(:splunk_hec) do
       },
     }
 
-    Puppet.info "Submitting report to Splunk at #{splunk_url}"
+    Puppet.info "Submitting report to Splunk at #{get_splunk_url('summary')}"
     submit_request event
     if record_event
       store_event event

--- a/lib/puppet/util/splunk_hec.rb
+++ b/lib/puppet/util/splunk_hec.rb
@@ -42,8 +42,11 @@ module Puppet::Util::Splunk_hec
   end
 
   def submit_request(body)
+    # we want users to be able to provide different tokens per sourcetype if they want
+    token_type = body['sourcetype'].split(':')[1]
+    token_name = "token_#{token_type}"
     http = create_http
-    token = settings['token'] || raise(Puppet::Error, 'Must provide token parameter to splunk class')
+    token = settings[token_name] || settings['token'] || raise(Puppet::Error, 'Must provide token parameter to splunk class')
     req = Net::HTTP::Post.new(@uri.path.to_str)
     req.add_field('Authorization', "Splunk #{token}")
     req.add_field('Content-Type', 'application/json')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,10 @@ class splunk_hec (
   Optional[String] $pe_console = undef,
   Optional[Integer] $timeout = undef,
   Optional[String] $ssl_ca = undef,
+  Optional[String] $token_summary = undef,
+  Optional[String] $token_detailed = undef,
+  Optional[String] $token_facts = undef,
+  Optional[String] $token_metrics = undef,
 ) {
 
   if $enable_reports {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,9 +12,11 @@ class splunk_hec (
   Optional[Integer] $timeout = undef,
   Optional[String] $ssl_ca = undef,
   Optional[String] $token_summary = undef,
-  Optional[String] $token_detailed = undef,
   Optional[String] $token_facts = undef,
   Optional[String] $token_metrics = undef,
+  Optional[String] $url_summary = undef,
+  Optional[String] $url_facts = undef,
+  Optional[String] $url_metrics = undef,
 ) {
 
   if $enable_reports {

--- a/templates/splunk_hec.yaml.epp
+++ b/templates/splunk_hec.yaml.epp
@@ -21,12 +21,18 @@
 <% if $splunk_hec::token_summary { -%>
 "token_summary" : "<%= $splunk_hec::token_summary %>"
 <% } -%>
-<% if $splunk_hec::token_detailed { -%>
-"token_detailed" : "<%= $splunk_hec::token_detailed %>"
-<% } -%>
 <% if $splunk_hec::token_facts { -%>
 "token_facts" : "<%= $splunk_hec::token_facts %>"
 <% } -%>
 <% if $splunk_hec::token_metrics { -%>
 "token_metrics" : "<%= $splunk_hec::token_metrics %>"
+<% } -%>
+<% if $splunk_hec::url_summary { -%>
+"url_summary" : "<%= $splunk_hec::url_summary %>"
+<% } -%>
+<% if $splunk_hec::url_facts { -%>
+"url_facts" : "<%= $splunk_hec::url_facts %>"
+<% } -%>
+<% if $splunk_hec::url_metrics { -%>
+"url_metrics" : "<%= $splunk_hec::url_metrics %>"
 <% } -%>

--- a/templates/splunk_hec.yaml.epp
+++ b/templates/splunk_hec.yaml.epp
@@ -18,3 +18,15 @@
 <% if $splunk_hec::record_event { -%>
 "record_event" : "<%= $splunk_hec::record_event %>"
 <% } -%>
+<% if $splunk_hec::token_summary { -%>
+"token_summary" : "<%= $splunk_hec::token_summary %>"
+<% } -%>
+<% if $splunk_hec::token_detailed { -%>
+"token_detailed" : "<%= $splunk_hec::token_detailed %>"
+<% } -%>
+<% if $splunk_hec::token_facts { -%>
+"token_facts" : "<%= $splunk_hec::token_facts %>"
+<% } -%>
+<% if $splunk_hec::token_metrics { -%>
+"token_metrics" : "<%= $splunk_hec::token_metrics %>"
+<% } -%>


### PR DESCRIPTION
In order for data to be submitted to different indexes in Splunk, we need to be sending it to different HEC's. This updates the splunk_hec.rb util functions to check to see if there is a user provided hec token matching the puppet sourcetype that the event specifies and uses that.

If there is no custom HEC present, it falls back to using the global HEC token.