### PR TITLE
(PIE-82) Enable support for CD4PE

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ master:
     terminus: puppetdb
     cache: splunk_hec
 ```
-- Set this routes file instead of the default one with `pupept config set route_file /etc/puppetlabs/puppet/splunk_routes.yaml --section master`
+- Set this routes file instead of the default one with `puppet config set route_file /etc/puppetlabs/puppet/splunk_routes.yaml --section master`
 - To configure which facts to collect (such as custom facts) add the `collect_facts` parameter in the `splunk_hec` class and modify the array of facts presented. The following facts are collected regardless to ensure the functionality of the Puppet Report Viever:
 
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ puppet-splunk_hec
 Breaking Changes
 -----------
 - splunk_hec::url parameter now expects a full URI of https://servername:8088/services/collector
-- Switches to the fact terminus cache setting via routes.yaml to ensure compatibility with CD4PE
+- Switches to the fact terminus cache setting via routes.yaml to ensure compatibility with CD4PE, see Fact Terminus Support for guides on how to change it. Prior to deploying this module, remove the setting `facts_terminus` from the `puppet_enterprise::profile::master` class in the `PE Master` node group in your environment if you set it in previous revisions of this module. It will prevent PE from operating normally if left on.
 
 Description
 -----------
@@ -117,14 +117,9 @@ Fact Terminus Support
 
 The `splunk_hec` module provides a fact terminus that will send a configurable set of facts to the same HEC that the report processor is using, however as a `puppet:facts` sourcetype. This populates the Details and Inventory tabs in the Puppet Report Viewer. 
 
-- Create a custom splunk_routes.yaml file to override where facts are cached 
-```yaml
-master:
-  facts:
-    terminus: puppetdb
-    cache: splunk_hec
-```
-- Set this routes file instead of the default one with `puppet config set route_file /etc/puppetlabs/puppet/splunk_routes.yaml --section master`
+- Set the parameter `splunk_hec::manage_routes` to `true`. In the PE console, this would be by adding `manage_routes` in the `Classification -> PE Infrastructure -> Master -> Configuration` view under the `splunk_hec`
+- Run Puppet on the machines in that node group
+- PE PuppetServer will restart once the new routes.yaml is deployed and configured.
 - To configure which facts to collect (such as custom facts) add the `collect_facts` parameter in the `splunk_hec` class and modify the array of facts presented. The following facts are collected regardless to ensure the functionality of the Puppet Report Viever:
 
 ```
@@ -139,6 +134,20 @@ master:
 'producer'
 'environment'
 ```
+
+### Advanced Settings:
+
+The splunk_hec module also supports customizing the `fact_terminus` and `facts_cache_terminus` names in the custom routes.yaml it deploys. If you are using a different facts_terminus (ie, not PuppetDB), you will want to set that parameter.
+
+If you are already using a custom routes.yaml, these are the equivalent instructions of what the splunk_hec module does, the most important setting is configuring `cache: splunk_hec`
+- Create a custom splunk_routes.yaml file to override where facts are cached 
+```yaml
+master:
+  facts:
+    terminus: puppetdb
+    cache: splunk_hec
+```
+- Set this routes file instead of the default one with `puppet config set route_file /etc/puppetlabs/puppet/splunk_routes.yaml --section master`
 
 
 Tasks

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ puppet-splunk_hec
 
 Breaking Changes
 -----------
-- splunk_hec::url parameter now expects a full URI of https://servername:8088/services/collector
-- Switches to the fact terminus cache setting via routes.yaml to ensure compatibility with CD4PE, see Fact Terminus Support for guides on how to change it. Prior to deploying this module, remove the setting `facts_terminus` from the `puppet_enterprise::profile::master` class in the `PE Master` node group in your environment if you set it in previous revisions of this module. It will prevent PE from operating normally if left on.
+- 0.5.0 splunk_hec::url parameter now expects a full URI of https://servername:8088/services/collector
+- 0.5.0 -> 0.6.0 Switches to the fact terminus cache setting via routes.yaml to ensure compatibility with CD4PE, see Fact Terminus Support for guides on how to change it. Prior to deploying this module, remove the setting `facts_terminus` from the `puppet_enterprise::profile::master` class in the `PE Master` node group in your environment if you set it in previous revisions of this module (olders than 0.6.0). It will prevent PE from operating normally if left on.
 
 Description
 -----------

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ puppet-splunk_hec
 Breaking Changes
 -----------
 - splunk_hec::url parameter now expects a full URI of https://servername:8088/services/collector
+- Switches to the fact terminus cache setting via routes.yaml to ensure compatibility with CD4PE
 
 Description
 -----------
@@ -116,7 +117,14 @@ Fact Terminus Support
 
 The `splunk_hec` module provides a fact terminus that will send a configurable set of facts to the same HEC that the report processor is using, however as a `puppet:facts` sourcetype. This populates the Details and Inventory tabs in the Puppet Report Viewer. 
 
-- In the PE Master configuration group, add the parameter setting `facts_terminus` and set it to `splunk_hec`.
+- Create a custom splunk_routes.yaml file to override where facts are cached 
+```yaml
+master:
+  facts:
+    terminus: puppetdb
+    cache: splunk_hec
+```
+- Set this routes file instead of the default one with `pupept config set route_file /etc/puppetlabs/puppet/splunk_routes.yaml --section master`
 - To configure which facts to collect (such as custom facts) add the `collect_facts` parameter in the `splunk_hec` class and modify the array of facts presented. The following facts are collected regardless to ensure the functionality of the Puppet Report Viever:
 
 ```

--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ Known Issues
 * Automated testing could use work
 
 
-Author
+Authors
 ------
+P.uppet I.ntegrations E.ngineering Team
 Chris Barker <cbarker@puppet.com>
+Helen Campbell <helen@puppet.com>
+Greg Hardy <greg.hardy@puppet.com>
+Bryan Jen <bryan.jen@puppet.com>

--- a/lib/puppet/indirector/facts/splunk_hec.rb
+++ b/lib/puppet/indirector/facts/splunk_hec.rb
@@ -9,7 +9,7 @@ class Puppet::Node::Facts::Splunk_hec < Puppet::Node::Facts::Yaml
        It uses PuppetDB to retrieve facts for catalog compilation."
 
   include Puppet::Util::Splunk_hec
-  
+
   def get_trusted_info(node)
     trusted = Puppet.lookup(:trusted_information) do
       Puppet::Context::TrustedInformation.local(node)
@@ -18,7 +18,7 @@ class Puppet::Node::Facts::Splunk_hec < Puppet::Node::Facts::Yaml
   end
 
   def profile(message, metric_id, &block)
-    message = "Splunk_hec: " + message
+    message = 'Splunk_hec: ' + message
     arity = Puppet::Util::Profiler.method(:profile).arity
     case arity
     when 1
@@ -27,7 +27,7 @@ class Puppet::Node::Facts::Splunk_hec < Puppet::Node::Facts::Yaml
       Puppet::Util::Profiler.profile(message, metric_id, &block)
     end
   end
-  
+
   def save(request)
     # yaml cache goes first
     super(request)

--- a/lib/puppet/indirector/facts/splunk_hec.rb
+++ b/lib/puppet/indirector/facts/splunk_hec.rb
@@ -1,16 +1,35 @@
-require 'puppet/indirector/facts/puppetdb'
+require 'puppet/indirector/facts/yaml'
+require 'puppet/util/profiler'
 require 'puppet/util/splunk_hec'
 
 # rubocop:disable Style/ClassAndModuleCamelCase
 # splunk_hec.rb
-class Puppet::Node::Facts::Splunk_hec < Puppet::Node::Facts::Puppetdb
-  desc "Save facts to Splunk over HEC and PuppetDB.
+class Puppet::Node::Facts::Splunk_hec < Puppet::Node::Facts::Yaml
+  desc "Save facts to Splunk over HEC and then to yamlcache.
        It uses PuppetDB to retrieve facts for catalog compilation."
 
   include Puppet::Util::Splunk_hec
+  
+  def get_trusted_info(node)
+    trusted = Puppet.lookup(:trusted_information) do
+      Puppet::Context::TrustedInformation.local(node)
+    end
+    trusted.to_h
+  end
 
+  def profile(message, metric_id, &block)
+    message = "Splunk_hec: " + message
+    arity = Puppet::Util::Profiler.method(:profile).arity
+    case arity
+    when 1
+      Puppet::Util::Profiler.profile(message, &block)
+    when 2, -2
+      Puppet::Util::Profiler.profile(message, metric_id, &block)
+    end
+  end
+  
   def save(request)
-    # puppetdb goes first
+    # yaml cache goes first
     super(request)
 
     profile('splunk_facts#save', [:splunk, :facts, :save, request.key]) do

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,7 +7,10 @@ class splunk_hec (
   Array $collect_facts = ['dmi','disks','partitions','processors','networking'],
   Boolean $enable_reports = false,
   Boolean $record_event = false,
+  Boolean $manage_routes = false,
   String $reports = 'puppetdb,splunk_hec',
+  String $facts_terminus = 'puppetdb',
+  String $facts_cache_terminus = 'splunk_hec',
   Optional[String] $pe_console = undef,
   Optional[Integer] $timeout = undef,
   Optional[String] $ssl_ca = undef,
@@ -26,6 +29,26 @@ class splunk_hec (
       section => 'master',
       setting => 'reports',
       value   => $reports,
+      notify  => Service['pe-puppetserver'],
+    }
+  }
+
+  if $manage_routes {
+    file { '/etc/puppetlabs/puppet/splunk_hec_routes.yaml':
+      ensure  => file,
+      owner   => pe-puppet,
+      group   => pe-puppet,
+      mode    => '0640',
+      content => epp('splunk_hec/splunk_hec_routes.yaml.epp'),
+      notify  => Service['pe-puppetserver'],
+    }
+    pe_ini_setting {'enable splunk_hec_routes.yaml':
+      ensure  => present,
+      path    => '/etc/puppetlabs/puppet/puppet.conf',
+      section => 'master',
+      setting => 'route_file',
+      value   => '/etc/puppetlabs/puppet/splunk_hec_routes.yaml',
+      require => File['/etc/puppetlabs/puppet/splunk_hec_routes.yaml'],
       notify  => Service['pe-puppetserver'],
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-splunk_hec",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": "Puppet, Inc.",
   "summary": "Puppet report processor using Splunk HEC",
   "license": "Apache-2.0",

--- a/templates/splunk_hec_routes.yaml.epp
+++ b/templates/splunk_hec_routes.yaml.epp
@@ -1,0 +1,6 @@
+# managed by puppet splunk_hec module
+---
+master:
+  facts:
+    terminus: "<%= $splunk_hec::facts_terminus %>"
+    cache: "<%= $splunk_hec::facts_cache_terminus %>"


### PR DESCRIPTION
Moves the splunk_hec fact terminus from being the primary terminus to the cache terminus. This allows for any code that checks to see if puppetdb is set as the primary terminus to work without modification (ie, catalog compilation in 2019.1, CD4PE impact analysis).

See Breaking Changes in ReadMe on steps you must take to adopt this change if you've enabled Fact support previously. In order to facility this change, we had to remove support for PuppetDB forwarding from splunk_hec and move it to yaml forwarding, as that is the role of the cache setting traditionally (to store facts as a yaml cache locally on the puppetserver).