### PR TITLE
(MAINT) Fix Puppet 4 Compatibility

### DIFF
--- a/lib/puppet/reports/splunk_hec.rb
+++ b/lib/puppet/reports/splunk_hec.rb
@@ -27,6 +27,12 @@ Puppet::Reports.register_report(:splunk_hec) do
       },
     }
 
+    # puppet 4 compatibility, code_id and job_id were added in puppet 5
+    if report_format.to_i < 7
+      job_id = nil
+      code_id = nil
+    end
+
     event = {
       'host' => host,
       'time' => epoch,


### PR DESCRIPTION
Prior to this change, Puppet 4 installs would fail due to lack of
`job_id` or `code_id` in the report format.

This change detects the report format version and adds those variables
as needed to prevent errors.