### PR TITLE
PIE-178 Multiple Metrics in stdin

### DIFF
--- a/lib/puppet/application/splunk_hec.rb
+++ b/lib/puppet/application/splunk_hec.rb
@@ -57,9 +57,15 @@ class Puppet::Application::Splunk_hec < Puppet::Application
   end
 
   def main
-    data = JSON.parse(STDIN.read)
+    datainput = STDIN.read
+    cleaned = datainput.gsub("\n}{\n","\n},{\n")
+    cleaned = cleaned.insert(0, '[')
+    cleaned = cleaned.insert(-1,']')
+    data = JSON.parse(cleaned)
     sourcetype = options[:sourcetype].to_s
-    send_pe_metrics(data, sourcetype) if options[:pe_metrics]
-    upload_report(data, sourcetype) if options[:saved_report]
+    data.each do |server|
+      send_pe_metrics(server, sourcetype) if options[:pe_metrics]
+      upload_report(server, sourcetype) if options[:saved_report]
+    end
   end
 end

--- a/lib/puppet/application/splunk_hec.rb
+++ b/lib/puppet/application/splunk_hec.rb
@@ -59,7 +59,7 @@ class Puppet::Application::Splunk_hec < Puppet::Application
   def main
     begin
       datainput = STDIN.read
-    rescue Exception => e  
+    rescue StandardError => e  
       Puppet.info "Unable to parse STDIN, is it text?"
       Puppet.info e.message
       Puppet.info e.backtrace.inspect
@@ -67,7 +67,13 @@ class Puppet::Application::Splunk_hec < Puppet::Application
     cleaned = datainput.gsub("\n}{\n","\n},{\n")
     cleaned = cleaned.insert(0, '[')
     cleaned = cleaned.insert(-1,']')
-    data = JSON.parse(cleaned)
+    begin
+      data = JSON.parse(cleaned)
+    rescue StandardError => e  
+      Puppet.info "Unable to parse json from stdin"
+      Puppet.info e.message
+      Puppet.info e.backtrace.inspect
+    end
     sourcetype = options[:sourcetype].to_s
     data.each do |server|
       send_pe_metrics(server, sourcetype) if options[:pe_metrics]

--- a/lib/puppet/application/splunk_hec.rb
+++ b/lib/puppet/application/splunk_hec.rb
@@ -57,7 +57,13 @@ class Puppet::Application::Splunk_hec < Puppet::Application
   end
 
   def main
-    datainput = STDIN.read
+    begin
+      datainput = STDIN.read
+    rescue Exception => e  
+      Puppet.info "Unable to parse STDIN, is it text?"
+      Puppet.info e.message
+      Puppet.info e.backtrace.inspect
+    end
     cleaned = datainput.gsub("\n}{\n","\n},{\n")
     cleaned = cleaned.insert(0, '[')
     cleaned = cleaned.insert(-1,']')

--- a/lib/puppet/application/splunk_hec.rb
+++ b/lib/puppet/application/splunk_hec.rb
@@ -59,18 +59,18 @@ class Puppet::Application::Splunk_hec < Puppet::Application
   def main
     begin
       datainput = STDIN.read
-    rescue StandardError => e  
-      Puppet.info "Unable to parse STDIN, is it text?"
+    rescue StandardError => e
+      Puppet.info 'Unable to parse STDIN, is it text?'
       Puppet.info e.message
       Puppet.info e.backtrace.inspect
     end
-    cleaned = datainput.gsub("\n}{\n","\n},{\n")
+    cleaned = datainput.gsub("\n}{\n", "\n},{\n")
     cleaned = cleaned.insert(0, '[')
-    cleaned = cleaned.insert(-1,']')
+    cleaned = cleaned.insert(-1, ']')
     begin
       data = JSON.parse(cleaned)
-    rescue StandardError => e  
-      Puppet.info "Unable to parse json from stdin"
+    rescue StandardError => e
+      Puppet.info 'Unable to parse json from stdin'
       Puppet.info e.message
       Puppet.info e.backtrace.inspect
     end


### PR DESCRIPTION
Before this we assumed we would receive parsable json on standard in from the metrics executable regardless of number of systems involved.

Instead it would output a json hash for each server and not attempt to combine them into a valid array. This converts any hash received on STDIN into an array of hashes (even if its just an array of 1).