### PR TITLE
Added the ability to change resources format

### DIFF
--- a/lib/facter/splunk_hec_is_pe.rb
+++ b/lib/facter/splunk_hec_is_pe.rb
@@ -1,0 +1,5 @@
+Facter.add(:splunk_hec_is_pe) do
+  setcode do
+    File.readable?('/opt/puppetlabs/server/pe_version')
+  end
+end

--- a/lib/puppet/application/splunk_hec.rb
+++ b/lib/puppet/application/splunk_hec.rb
@@ -1,5 +1,5 @@
 require 'puppet/application'
-require 'puppet/util/splunk_hec'
+require File.dirname(__FILE__) + '/../util/splunk_hec.rb'
 
 # rubocop:disable Style/ClassAndModuleCamelCase
 # splunk_hec.rb

--- a/lib/puppet/indirector/facts/splunk_hec.rb
+++ b/lib/puppet/indirector/facts/splunk_hec.rb
@@ -1,6 +1,6 @@
 require 'puppet/indirector/facts/yaml'
 require 'puppet/util/profiler'
-require 'puppet/util/splunk_hec'
+require File.dirname(__FILE__) + '/../../util/splunk_hec.rb'
 
 # rubocop:disable Style/ClassAndModuleCamelCase
 # splunk_hec.rb

--- a/lib/puppet/reports/splunk_hec.rb
+++ b/lib/puppet/reports/splunk_hec.rb
@@ -95,7 +95,15 @@ Puppet::Reports.register_report(:splunk_hec) do
     end
 
     if add_resources
-      event['event']['resource_events'] = resource_statuses.select { |_k, v| v.events.count > 0 }
+      resource_events_hash = resource_statuses.select { |_k, v| v.events.count > 0 }
+      # We may want to return this as a hash or an array. Splunk deals better
+      # with arrays but we need to give people the choice so as to not break
+      # existing reports
+      event['event']['resource_events'] = if settings['summary_resources_format'] == 'array'
+                                            resource_events_hash.map { |_k, v| v }
+                                          else
+                                            resource_events_hash
+                                          end
     end
 
     Puppet.info "Submitting report to Splunk at #{get_splunk_url('summary')}"

--- a/lib/puppet/reports/splunk_hec.rb
+++ b/lib/puppet/reports/splunk_hec.rb
@@ -1,4 +1,4 @@
-require 'puppet/util/splunk_hec'
+require File.dirname(__FILE__) + '/../util/splunk_hec.rb'
 
 Puppet::Reports.register_report(:splunk_hec) do
   desc 'Submits just a report summary to Splunk HEC endpoint'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,7 +27,7 @@ class splunk_hec (
   Optional[Boolean] $include_logs_corrective_change = false,
   Optional[Array] $include_resources_status = undef,
   Optional[Boolean] $include_resources_corrective_change = false,
-
+  String $summary_resources_format = 'hash',
 ) {
 
   # Account for the differences in Puppet Enterprise and open source

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -47,11 +47,16 @@ describe 'splunk_hec' do
     }
     MANIFEST
   end
+
   let(:params) do
     {
       'url'   => 'foo_url',
       'token' => 'foo_token',
     }
+  end
+
+  let(:facts) do
+    { splunk_hec_is_pe: true }
   end
 
   context 'enable_reports is false' do

--- a/templates/splunk_hec.yaml.epp
+++ b/templates/splunk_hec.yaml.epp
@@ -57,3 +57,6 @@
 <% if $splunk_hec::include_resources_corrective_change { -%>
 "include_resources_corrective_change" : "<%= $splunk_hec::include_resources_corrective_change %>"
 <% } -%>
+<% if $splunk_hec::summary_resources_format { -%>
+"summary_resources_format" : "<%= $splunk_hec::summary_resources_format %>"
+<% } -%>


### PR DESCRIPTION
These being a hash is default Puppet behaviour, but this can make writing splunk queries very hard. Arrays are probably preferable but we likely don't want to change the default behaviour without a major release