### PR TITLE
(Maint) update changelog for 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [v0.8.0](https://github.com/puppetlabs/puppetlabs-splunk_hec/tree/v0.8.0) (2020-05-07)
+
+[Full Changelog](https://github.com/puppetlabs/puppetlabs-splunk_hec/compare/v0.7.1...v0.8.0)
+
+### Fixed
+
+- Move the breaking changes to known issues section in readme [\#33](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/33) ([HelenCampbell](https://github.com/HelenCampbell))
+
+### UNCATEGORIZED PRS; GO LABEL THEM
+
+- \(PIE-265\) refactor docs [\#43](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/43) ([gsparks](https://github.com/gsparks))
+- fix single quote issue in classifier [\#42](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/42) ([mrzarquon](https://github.com/mrzarquon))
+- \(PIE-178\) Parse line-delimited JSON metrics [\#39](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/39) ([Sharpie](https://github.com/Sharpie))
+- Enable extra data [\#38](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/38) ([mrzarquon](https://github.com/mrzarquon))
+- PIE-178 Multiple Metrics in stdin [\#36](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/36) ([mrzarquon](https://github.com/mrzarquon))
+- \(maint\) Add CODEOWNERS file [\#35](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/35) ([bmjen](https://github.com/bmjen))
+
 ## [v0.7.1](https://github.com/puppetlabs/puppetlabs-splunk_hec/tree/v0.7.1) (2019-07-01)
 
 [Full Changelog](https://github.com/puppetlabs/puppetlabs-splunk_hec/compare/v0.7.0...v0.7.1)
@@ -12,7 +29,11 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [v0.7.0](https://github.com/puppetlabs/puppetlabs-splunk_hec/tree/v0.7.0) (2019-06-25)
 
-[Full Changelog](https://github.com/puppetlabs/puppetlabs-splunk_hec/compare/0.6.0...v0.7.0)
+[Full Changelog](https://github.com/puppetlabs/puppetlabs-splunk_hec/compare/0.7.0...v0.7.0)
+
+## [0.7.0](https://github.com/puppetlabs/puppetlabs-splunk_hec/tree/0.7.0) (2019-06-17)
+
+[Full Changelog](https://github.com/puppetlabs/puppetlabs-splunk_hec/compare/0.6.0...0.7.0)
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ See the `plans/` directory for working examples of apply and result usage.
 
 ## Known Issues
 ------------
-* Integration with puppet_metrics_collection only works on version 5.2.0 currently, waiting on 5.4.0 release
+* Integration with puppet_metrics_collection only works on version >= 6.0.0
 * SSL Validation is under active development and behavior may change
 * Automated testing could use work
 
@@ -122,7 +122,7 @@ This module is hooked up with an automatic release process using travis. To prov
 
 Full process to prepare for a release:
 
-Update metadata.json to reflect new module release version (0.7.0)
+Update metadata.json to reflect new module release version (0.8.0)
 Run `bundle exec rake changelog` to update the CHANGELOG automatically
 Submit PR for changes
 

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/puppet_metrics_collector",
-      "version_requirement": ">= 5.2.0 < 5.3.0"
+      "version_requirement": ">= 6.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Updated version number to 0.8.0 and updated the puppet_metrics_collector
to require version 6.0.0.