### PR TITLE
(PIE-296) Add option to dynamically calculate the 'reports' setting

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,9 @@
 ---
 fixtures:
+  forge_modules:
+    inifile:
+      repo: "puppetlabs/inifile"
+      ref: "4.2.0"
   repositories:
     facts: 'git://github.com/puppetlabs/puppetlabs-facts.git'
     puppet_agent: 'git://github.com/puppetlabs/puppetlabs-puppet_agent.git'

--- a/docs/custom_installation.md
+++ b/docs/custom_installation.md
@@ -34,7 +34,7 @@ The steps below will help install and troubleshoot the report processor on a sin
 	- Press Refresh to ensure the splunk_hec class is loaded
 	- Add new class `splunk_hec`
 	- From the `Parameter name` select atleast `url` and `token` and provide the same attributes from the testing configuration file
-	- Optionally set `enable_reports` to `true` if there isn't another component managing the servers reports setting, otherwise manually add `splunk_hec` to the settings as described in the manual steps
+	- Optionally set `enable_reports` to `true` if there isn't another component managing the servers reports setting, otherwise manually add `splunk_hec` to the settings as described in the manual steps. Note that if `enable_reports` is set to `true`, then you can have the module automatically add the `splunk_hec` report processor to the servers reports setting by setting the `reports` parameter to the empty string, `''`.
 	- Commit changes and run Puppet. It is best to navigate to the PE Certificate Authority Classification gorup and run Puppet there first, before running Puppet on the remaining machines
 
 9. For Inventory support in the Puppet Report Viewer, see the [Fact Terminus Support](fact_terminus_support.md)

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'splunk_hec' do
+  let(:pre_condition) do
+    <<-MANIFEST
+    # Define the pe-puppetserver service
+    Service { 'pe-puppetserver':
+    }
+
+    # pe_ini_setting is a PE-only resource. Since PE modules are private, we
+    # make the resource a defined type for the unit tests. Note that we still
+    # have to use pe_ini_setting instead of ini_setting for backwards compatibility.
+    define pe_ini_setting (
+      Optional[Any] $ensure  = undef,
+      Optional[Any] $path    = undef,
+      Optional[Any] $section = undef,
+      Optional[Any] $setting = undef,
+      Optional[Any] $value   = undef,
+    ) {
+      ini_setting { $title:
+        ensure  => $ensure,
+        path    => $path,
+        section => $section,
+        setting => $setting,
+        value   => $value,
+      }
+    }
+    MANIFEST
+  end
+  let(:params) do
+    {
+      'url'   => 'foo_url',
+      'token' => 'foo_token',
+    }
+  end
+
+  context 'enable_reports is false' do
+    let(:params) do
+      p = super()
+      p['enable_reports'] = false
+      p
+    end
+
+    it { is_expected.not_to contain_pe_ini_setting('enable splunk hec') }
+  end
+
+  context 'enable_reports is true' do
+    let(:params) do
+      p = super()
+      p['enable_reports'] = true
+      p
+    end
+
+    context "sets 'reports' setting to 'puppetdb,splunk_hec' (default behavior)" do
+      it { is_expected.to contain_pe_ini_setting('enable splunk_hec').with_value('puppetdb,splunk_hec') }
+    end
+
+    context "set 'reports' setting to $reports if $reports != ''" do
+      let(:params) do
+        p = super()
+        p['reports'] = 'foo,bar,baz'
+        p
+      end
+
+      it { is_expected.to contain_notify('reports param deprecation warning') }
+      it { is_expected.to contain_pe_ini_setting('enable splunk_hec').with_value('foo,bar,baz') }
+    end
+
+    context "dynamically calculates the 'reports' setting if $reports == ''" do
+      let(:params) do
+        p = super()
+        p['reports'] = ''
+        p
+      end
+
+      # rspec-puppet caches the catalog in each test based on the params/facts.
+      # To clear the cache, we have to test each value in its own context block so
+      # that we can properly reset the params/facts. Since the params shouldn't
+      # change in each test, we'll be resetting the facts instead.
+      values = {
+        'none'                           => 'splunk_hec',
+        'foo'                            => 'foo, splunk_hec',
+        'foo, bar, baz'                  => 'foo, bar, baz, splunk_hec',
+        '  foo  '                        => 'foo, splunk_hec',
+        'foo  , bar  , baz'              => 'foo, bar, baz, splunk_hec',
+        'splunk_hec'                     => 'splunk_hec',
+        '  splunk_hec  '                 => '  splunk_hec  ',
+        'foo, splunk_hec'                => 'foo, splunk_hec',
+        '  foo, splunk_hec  '            => '  foo, splunk_hec  ',
+        'foo  , bar  , baz,  splunk_hec' => 'foo  , bar  , baz,  splunk_hec',
+        'foo, splunk_hec, bar'           => 'foo, splunk_hec, bar',
+      }
+      values.each do |value, expected_setting_value|
+        context "when setting = '#{value}'" do
+          let(:facts) do
+            # This is enough to reset the facts
+            {
+              '_report_settings_value' => value,
+            }
+          end
+
+          it do
+            allow(Puppet).to receive(:[]).with(anything).and_call_original
+            allow(Puppet).to receive(:[]).with(:reports).and_return(value)
+            is_expected.to contain_pe_ini_setting('enable splunk_hec').with_value(expected_setting_value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,10 @@
+RSpec.configure do |c|
+  # Use rspec mocks instead of mocha as per https://github.com/puppetlabs/puppetlabs_spec_helper#mock_with
+  # This configuration must be specified before the puppetlabs_spec_helper gem is loaded to avoid
+  # the deprecation warning.
+  c.mock_with :rspec
+end
+
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
 


### PR DESCRIPTION
This option is enabled when $reports == '' for backwards compatibility.
The option's useful because it no longer requires the user to specify
_all_ of their report processors in the $reports param. This leads to a
better UX especially when the user wants to use another report processor
module because they do not have to update the $reports parameter to
include that module's report processor.

Note that the $reports parameter will eventually be deprecated.

Signed-off-by: Enis Inan <enis.inan@puppet.com>