### PR TITLE
(MAINT) Expect report files on puppet server to have a .yaml extension.

### DIFF
--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -20,7 +20,7 @@ describe 'Verify the minimum install' do
     it 'Successfully creates a report after a simple puppet apply' do
       host = return_host
       run_shell('puppet apply -e \' notify { "Hello World" : }\' --reports=splunk_hec')
-      expect(run_shell("ls /opt/puppetlabs/puppet/cache/reports/#{host}").stdout).to match %r{\.json}
+      expect(run_shell("ls /opt/puppetlabs/puppet/cache/reports/#{host}").stdout).to match %r{\.yaml}
     end
 
     it 'Successfully sends data to an http endpoint' do


### PR DESCRIPTION
A test in the acceptance suite expects
/opt/puppetlabs/puppet/cache/reports/ on the puppet server to contain a
report file with a .json extension. This test is now failing because the
report file has a .yaml extension. We don't currently understand what
caused this change, but the reports are being generated without issue
which was the intent of the test. It's not clear that a change to this
module was responsible. This change modifies the expectation of the test
from a .json to a .yaml file.