### PR TITLE
(MAINT) Update project issues url

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "source": "https://github.com/puppetlabs/puppetlabs-splunk_hec",
   "project_page": "https://github.com/puppetlabs/puppetlabs-splunk_hec",
-  "issues_url": "https://github.com/puppetlabs/puppetlabs-splunk_hec/issues",
+  "issues_url": "https://tickets.puppetlabs.com/projects/PIE/issues",
   "dependencies": [
     {
       "name": "puppetlabs/puppet_metrics_collector",


### PR DESCRIPTION
The team will not be using Github issues to track work as it is
difficult to prioritize. This change updates the issues URL on the forge
to point at the PIE project in Jira so that any tickets created can be
triaged.