### PR TITLE
(MAINT) Revert Github Actions Change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         ruby-version: ${{ matrix.ruby_version }}
 
     - name: Static Checks
-      uses: RandomNoun7/action-litmus_spec@change_env_exports
+      uses: puppetlabs/action-litmus_spec@master
       with:
         puppet_gem_version: ${{ matrix.puppet_gem_version }}
         check: ${{ matrix.check }}


### PR DESCRIPTION
The fix for the github actions environment variable bug has been merged
into the upstream repository. This change reverts the workflow from
using a personal repo, back to the Puppetlabs repo.