### PR TITLE
Fix PDK Validate Errors

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,7 +33,9 @@ class splunk_hec (
   if $enable_reports {
     if $reports != '' {
       notify { "reports param deprecation warning" :
-        message  => "The 'reports' parameter is being deprecated in favor of having the module automatically add the 'splunk_hec' setting to puppet.conf. You can enable this behavior by setting 'reports' to '', the empty string, but please keep in mind that the 'reports' parameter will be removed in a future release.",
+        message  => "The 'reports' parameter is being deprecated in favor of having the module automatically add the 'splunk_hec' setting \
+        to puppet.conf. You can enable this behavior by setting 'reports' to '', the empty string, but please keep in mind that the \
+        'reports' parameter will be removed in a future release.",
         loglevel =>  'warning',
       }
 

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/puppet_metrics_collector",
-      "version_requirement": ">= 6.0.0"
+      "version_requirement": ">= 6.0.0 < 7.0"
     }
   ],
   "operatingsystem_support": [

--- a/plans/apply_example.pp
+++ b/plans/apply_example.pp
@@ -24,7 +24,12 @@ plan splunk_hec::apply_example (
       #notice("${node} returned a value: ${result.report}")
       notice("sending ${node}'s report to splunk")
       # this will use facts[clientcert] because we don't pass host
-      run_task('splunk_hec::bolt_apply', 'splunk_hec', report => $result.report, facts => $result.target.facts, plan_guid => $plan_guid, plan_name => $plan_name)
+      run_task('splunk_hec::bolt_apply', 'splunk_hec',
+        report    => $result.report,
+        facts     => $result.target.facts,
+        plan_guid => $plan_guid,
+        plan_name => $plan_name
+      )
       # this will set host to $node value - note: this will include the URI of pcp://$name vs $name as result from $clientcert value
       # run_task("splunk_hec::bolt_apply", 'splunk_bolt_apply', report => $result.report, facts => $result.target.facts, host => $node)
     } else {


### PR DESCRIPTION
This PR does not update the pdk compatibility version to latest because pdk wants to manage files that have not been properly prepped for pdk management. We would need to create a separate ticket for that work.