### PR TITLE
(MAINT) Fix gem user install bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         ruby-version: ${{ matrix.ruby_version }}
 
     - name: Static Checks
-      uses: puppetlabs/action-litmus_spec@master
+      uses: RandomNoun7/action-litmus_spec@MAINT-fix-user-install-bug
       with:
         puppet_gem_version: ${{ matrix.puppet_gem_version }}
         check: ${{ matrix.check }}


### PR DESCRIPTION
The puppetlabs/action-litmus_spec action installs the `bundler` gem
using the `--user-install` flag to the `gem install` command. Doing this
installs the `bundler` gem to a user folder that is not on the PATH.

For some reason this has starting causing CI to fail.

This change switches to a user fork of the action until a fix can be
implemented in the upstream repository.