### PR TITLE
(MAINT) Revert CI fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         ruby-version: ${{ matrix.ruby_version }}
 
     - name: Static Checks
-      uses: RandomNoun7/action-litmus_spec@MAINT-fix-user-install-bug
+      uses: puppetlabs/action-litmus_spec@master
       with:
         puppet_gem_version: ${{ matrix.puppet_gem_version }}
         check: ${{ matrix.check }}


### PR DESCRIPTION
The fix for the underlying issue has been merged into the upstream
actions repo. This change can now be reverted.