### PR TITLE
(PIE-431) Fix Open Source Compatibility

### DIFF
--- a/lib/facter/splunk_hec_is_pe.rb
+++ b/lib/facter/splunk_hec_is_pe.rb
@@ -1,0 +1,5 @@
+Facter.add(:splunk_hec_is_pe) do
+  setcode do
+    File.readable?('/opt/puppetlabs/server/pe_version')
+  end
+end

--- a/lib/puppet/application/splunk_hec.rb
+++ b/lib/puppet/application/splunk_hec.rb
@@ -1,5 +1,5 @@
 require 'puppet/application'
-require 'puppet/util/splunk_hec'
+require File.dirname(__FILE__) + '/../util/splunk_hec.rb'
 
 # rubocop:disable Style/ClassAndModuleCamelCase
 # splunk_hec.rb

--- a/lib/puppet/indirector/facts/splunk_hec.rb
+++ b/lib/puppet/indirector/facts/splunk_hec.rb
@@ -1,6 +1,6 @@
 require 'puppet/indirector/facts/yaml'
 require 'puppet/util/profiler'
-require 'puppet/util/splunk_hec'
+require File.dirname(__FILE__) + '/../../util/splunk_hec.rb'
 
 # rubocop:disable Style/ClassAndModuleCamelCase
 # splunk_hec.rb

--- a/lib/puppet/reports/splunk_hec.rb
+++ b/lib/puppet/reports/splunk_hec.rb
@@ -1,4 +1,4 @@
-require 'puppet/util/splunk_hec'
+require File.dirname(__FILE__) + '/../util/splunk_hec.rb'
 
 Puppet::Reports.register_report(:splunk_hec) do
   desc 'Submits just a report summary to Splunk HEC endpoint'

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -47,11 +47,16 @@ describe 'splunk_hec' do
     }
     MANIFEST
   end
+
   let(:params) do
     {
       'url'   => 'foo_url',
       'token' => 'foo_token',
     }
+  end
+
+  let(:facts) do
+    { splunk_hec_is_pe: true }
   end
 
   context 'enable_reports is false' do


### PR DESCRIPTION
Prior to this change the values for the of the resource parameters were
hard coded to match Puppet Enterprise.

This change enables the module to determine if it is in a PE environment
or Open Source, and select the appropriate values to avoid errors.

It also fixes a bug in the `requires` statements to account for path
differences between PE and Open Source.