### PR TITLE
(MAINT) Add pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=$(git hash-object -t tree /dev/null)
+fi
+
+# Whitespace check copied from the template pre-commit hook.
+git diff-index --check --cached $against --
+
+bundle exec rake \
+ syntax \
+ lint \
+ metadata_lint \
+ check:symlinks \
+ check:git_ignore \
+ check:dot_underscore \
+ check:test_file \
+ rubocop \
+ spec


### PR DESCRIPTION
This change adds a pre-commit hook that runs synax and linting checks,
then runs spec prep, and runs spec tests, before allowing a commit.

Acceptance tests are not run.

To ensure your local git installation runs any hooks we put in the
.githooks folder you need to run the following command on your local
machine. `git config core.hooksPath .githooks`