### PR TITLE
(MAINT) - Create a testing account to pull apps from Splunkbase

### DIFF
--- a/spec/support/acceptance/splunk/docker-compose.yml
+++ b/spec/support/acceptance/splunk/docker-compose.yml
@@ -12,8 +12,8 @@ services:
       # like github for testing.
       - SPLUNK_APPS_URL=https://splunkbase.splunk.com/app/4413/release/3.0.1/download
       # TODO: Make a PIE account
-      - SPLUNKBASE_USERNAME=gregsparks
-      - SPLUNKBASE_PASSWORD=2Riboflavin!
+      - SPLUNKBASE_USERNAME=gregsparkspie
+      - SPLUNKBASE_PASSWORD=5736kKtVRkgFBs4@
       - SPLUNK_PASSWORD=piepiepie
     volumes:
       # default.yml is a mechanism to load splunk settings that would normally


### PR DESCRIPTION
The Splunk container requires Splunkbase credentials to pull the Report
Viewer App from Splunkbase and install it into the container for
testing. This change adds credentials that are only used for this and
can be easily recreated. Any Splunkbase account will do. Password has
been changed on the other account that was here previously which got
some editing permission after the creds were committed here.