### PR TITLE
(PIE-459) Fix Ruby Loadpath for collector script

### DIFF
--- a/files/splunk_hec_collect_api_events.rb
+++ b/files/splunk_hec_collect_api_events.rb
@@ -1,12 +1,26 @@
 #!/opt/puppetlabs/puppet/bin/ruby
-
-require 'common_events_library'
 require 'fileutils'
 require 'benchmark'
 require 'json'
 require 'net/https'
 require 'time'
 require 'yaml'
+require 'find'
+
+modulepaths = `puppet config print modulepath`.chomp.split(':')
+
+catch :done do
+  modulepaths.each do |modulepath|
+    Find.find(modulepath) do |path|
+      if path =~ %r{common_events_library.gemspec}
+        $LOAD_PATH.unshift("#{File.dirname(path)}/lib")
+        throw :done
+      end
+    end
+  end
+end
+
+require 'common_events_library'
 
 STORE_DIR = ENV['STORE_DIR'] || '/etc/puppetlabs/splunk/'
 


### PR DESCRIPTION
When the splunk_hec_collect_api_events.rb script is executed, the
`$LOAD_PATH` variable is not set to allow `require` to find the
`common_events_library` gem even though the module has been installed
into Puppet.

This change asks Puppet where the modules are installed, and finds the
correct module and adds the correct directory to `$LOAD_PATH` so that
requires statement will work.