### PR TITLE
(MAINT) Fix PATH Variable and Docker Rate Limit

### DIFF
--- a/files/splunk_hec_collect_api_events.rb
+++ b/files/splunk_hec_collect_api_events.rb
@@ -7,6 +7,8 @@ require 'time'
 require 'yaml'
 require 'find'
 
+ENV['PATH'] = "#{ENV['PATH']}:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin"
+
 modulepaths = `puppet config print modulepath`.chomp.split(':')
 confdir = `puppet config print confdir`.chomp
 

--- a/spec/support/acceptance/splunk/docker-compose.yml
+++ b/spec/support/acceptance/splunk/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2.0"
 
 services:
   enterprise:
-    image: splunk/splunk:latest
+    image: artifactory.delivery.puppetlabs.net:5000/splunk/splunk:latest
     hostname: splunk_instance
     environment:
       - SPLUNK_START_ARGS=--accept-license


### PR DESCRIPTION
When running from `cron` we found that the PATH variable does not have
the expected directories added. This caused shell invocation of `puppet`
to fail because the program could not be found.

This change adds a normal set of directories back to PATH.

This change also points `docker-compose.yaml` at the internal
artifactory instance to avoid Docker Hub rate limits.