### PR TITLE
(MAINT) Fix Ruby Errors in Jenkins CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline{
         label 'worker'
     }
     environment {
-      RUBY_VERSION='2.5.1'
+      RUBY_VERSION='2.5.7'
       GEM_SOURCE='https://artifactory.delivery.puppetlabs.net/artifactory/api/gems/rubygems/'
       RAKE_SETUP_TASK='rake acceptance:setup'
       RAKE_TEST_TASK='rake acceptance:run_tests'

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -10,7 +10,16 @@ describe 'Verify the minimum install' do
       hasrestart => true,
       restart    => "service pe-puppetserver reload",
     }
-    class { 'splunk_hec': url => "http://localhost:8088/services/collector/event", token => 'abcd1234', record_event => true }
+
+    class { 'splunk_hec':
+      url                    => 'http://localhost:8088/services/collector/event',
+      token                  => 'abcd1234',
+      record_event           => true,
+      pe_username            => 'admin',
+      pe_console             => 'localhost',
+      pe_password            => Sensitive('pie'),
+      include_api_collection => true,
+    }
     MANIFEST
 
     it 'Sets up the pe-puppetserver service and splunk_hec class' do
@@ -34,7 +43,15 @@ describe 'Verify the minimum install' do
           hasrestart => true,
           restart    => "service pe-puppetserver reload",
         }
-        class { 'splunk_hec': url => 'notanendpoint/nicetry', token => '', record_event => true }
+        class { 'splunk_hec':
+          url                    => 'notanendpoint/nicetry',
+          token                  => '',
+          record_event           => true,
+          pe_username            => 'admin',
+          pe_console             => 'localhost',
+          pe_password            => Sensitive('pie'),
+          include_api_collection => true,
+        }
         MANIFEST
       apply_manifest(failmanifest, catch_failures: true)
       cmd = 'cat /etc/puppetlabs/code/environments/production/modules/splunk_hec/examples/foo.json | puppet splunk_hec --sourcetype puppet:summary --saved_report'


### PR DESCRIPTION
The Ruby version needs to be updated to solve a dependency problem in
CI.