### PR TITLE
(MAINT) Default include_api_collection parameter to false

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,7 +29,7 @@ class splunk_hec (
   Optional[Boolean] $include_logs_corrective_change = false,
   Optional[Array] $include_resources_status = undef,
   Optional[Boolean] $include_resources_corrective_change = false,
-  Optional[Boolean] $include_api_collection = true,
+  Optional[Boolean] $include_api_collection = false,
   String $summary_resources_format = 'hash',
 ) {
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -102,7 +102,7 @@ describe 'splunk_hec' do
     end
 
     context 'handles $include_api_collection correctly' do
-      it { is_expected.to contain_cron('collectpeapi') }
+      it { is_expected.to have_cron_resource_count(0) }
 
       context 'with api collection turned off' do
         let(:params) do


### PR DESCRIPTION
When installing the module users who do not wish to use api collection
will be greeted with a validation error if the include_api_collection
parameter is set to true, but the pe_console, pe_username, and
pe_password parameters are not set. This changes the default to be false
so that exising users who are not using the api collection features will
not run into this validation.