### PR TITLE
(PIE-471) Provide default value for console url

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,9 +179,10 @@ The splunk_hec module allows the posting of PE orchestrator and activity service
 #### Configuration
 
 1. From your PE console, set the `include_api_collection` parameter in the splunk_hec class to true.
-2. Set the `pe_console` parameter to the url of the pe console you want to use.
-3. Set the `pe_username` parameter to a pe user with read access to the Orchestrator and Activity Service API's in Puppet Enterprise.
-4. Set the `pe_password` parameter to the password for the user above.
+2. Set the `pe_username` parameter to a pe user with read access to the Orchestrator and Activity Service API's in Puppet Enterprise.
+3. Set the `pe_password` parameter to the password for the user above.
+4. Optionally set the `pe_console` parameter if not the server this module is installed on.
+    - Should be the fqdn of the Puppet server you wish to use. Omit the http protocol.
 
 #### Installation
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,7 +14,7 @@ class splunk_hec (
   String $facts_cache_terminus = "splunk_hec",
   Optional[String] $pe_username = undef,
   Optional[Sensitive[String]] $pe_password = undef,
-  Optional[String] $pe_console = undef,
+  Optional[String] $pe_console = $settings::report_server,
   Optional[String] $reports = undef,
   Optional[Integer] $timeout = undef,
   Optional[String] $ssl_ca = undef,


### PR DESCRIPTION
This sets the pe_console parameter to default to the fqdn of the
Puppet server it's installed on.

Co-authored-by: Sharon Nam <sharon.name@puppet.com>