### PR TITLE
(PIE-475) Orchestrator and Events classes accept a pe token.

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,9 +179,13 @@ The splunk_hec module allows the posting of PE orchestrator and activity service
 #### Configuration
 
 1. From your PE console, set the `include_api_collection` parameter in the splunk_hec class to true.
-2. Set the `pe_username` parameter to a pe user with read access to the Orchestrator and Activity Service API's in Puppet Enterprise.
-3. Set the `pe_password` parameter to the password for the user above.
-4. Optionally set the `pe_console` parameter if not the server this module is installed on.
+2. Set up api authentication.
+  1. Username / Password Auth.
+    - Set the `pe_username` parameter to a pe user with read access to the Orchestrator and Activity Service API's in Puppet Enterprise.
+    - Set the `pe_password` parameter to the password for the user above.
+  2. Token Auth.
+    - Set the `pe_token` parameter for a user with read access to the Orchestrator and Activity Service API's in Puppet Enterprise.
+3. Optionally set the `pe_console` parameter if not the server this module is installed on.
     - Should be the fqdn of the Puppet server you wish to use. Omit the http protocol.
 
 #### Installation

--- a/files/splunk_hec_collect_api_events.rb
+++ b/files/splunk_hec_collect_api_events.rb
@@ -89,8 +89,8 @@ def main
   splunk_uri = URI(settings['url'])
 
   splunk_client        = CommonEventsHttp.new((splunk_uri.scheme + '://' + splunk_uri.host), port: 8088, ssl_verify: false)
-  orchestrator_client  = Orchestrator.new(settings['pe_console'], settings['pe_username'], settings['pe_password'], ssl_verify: false)
-  events_client        = Events.new(settings['pe_console'], settings['pe_username'], settings['pe_password'], ssl_verify: false)
+  orchestrator_client  = Orchestrator.new(settings['pe_console'], username: settings['pe_username'], password: settings['pe_password'], token: settings['pe_token'], ssl_verify: false)
+  events_client        = Events.new(settings['pe_console'], username: settings['pe_username'], password: settings['pe_password'], token: settings['pe_token'], ssl_verify: false)
 
   # source and process the orchestrator events
   previous_index = get_index(API_JOBS_STORE)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,7 @@ class splunk_hec (
   String $facts_cache_terminus = "splunk_hec",
   Optional[String] $pe_username = undef,
   Optional[Sensitive[String]] $pe_password = undef,
+  Optional[Sensitive[String]] $pe_token = undef,
   Optional[String] $pe_console = $settings::report_server,
   Optional[String] $reports = undef,
   Optional[Integer] $timeout = undef,

--- a/templates/splunk_hec.yaml.epp
+++ b/templates/splunk_hec.yaml.epp
@@ -15,6 +15,9 @@
 <% if $splunk_hec::pe_password{ -%>
 "pe_password" : "<%= $splunk_hec::pe_password.unwrap %>"
 <% } -%>
+<% if $splunk_hec::pe_token{ -%>
+"pe_token" : "<%= $splunk_hec::pe_token.unwrap %>"
+<% } -%>
 <% if $splunk_hec::timeout { -%>
 "timeout" : "<%= $splunk_hec::timeout %>"
 <% } -%>


### PR DESCRIPTION
In order to prevent a pe username and password from being written to the
splunk_heck.yaml config file, the user may pass in a long lived pe
token instead. If a username and password as well as a token is
provided, the token will be used.