### PR TITLE
(MAINT) Change source type names for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,18 +204,21 @@ The splunk_hec module allows the posting of PE orchestrator and activity service
 
 The events now will be collected and posted to your Splunk Server. These events will appear in the Splunk UI.
 
-There are two source types
+There are three possible source types.
 
-```bash
-puppet:events_summary
-puppet:activity
+```
+puppet:jobs
+puppet:activities_classifier
+puppet:activities_rbac
 ```
 
 #### Viewing the events
 
-Use `source="puppet:events_summary"` in your Splunk search field to show the orchestrator events.
+Use `source="puppet:jobs"` in your Splunk search field to show the orchestrator jobs. Orchestrator jobs includes Puppet agent runs kicked off from the `Run Puppet` button in the console, and it includes Tasks and Plans run from the console using the `Run Task` and `Run Plan` buttons.
 
-Use `source="puppet:activity"` in your Splunk search field to show the activity service events.
+Use `source="puppet:activities_classifier"` in your Splunk search field to show Classifier events coming from the Activity Service API. These events will include things like creating new classifier node groups, changing node group classification rules, etc.
+
+User `source="puppet:activities_rbac` in your Splunk search field to show rbac events coming from the Activity Service API. These events will include things like creating new local users, updating user metadata, etc.
 
 
 Advanced Settings

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -78,7 +78,7 @@ describe 'Verify the minimum install' do
       jobs = orchestrator.get_jobs(limit: 1)
 
       # Do a splunk search for the orchestrator sourcetype for the last 5 minutes
-      cmd = 'docker exec splunk_enterprise_1 bash -c \'sudo /opt/splunk/bin/splunk search sourcetype="puppet:events_summary" -earliest_time -5m -latest_time now -auth admin:piepiepie\''
+      cmd = 'docker exec splunk_enterprise_1 bash -c \'sudo /opt/splunk/bin/splunk search sourcetype="puppet:jobs" -earliest_time -5m -latest_time now -auth admin:piepiepie\''
 
       result = run_shell(cmd, expect_failures: true)
       events = result['stdout'].split("\n")


### PR DESCRIPTION
This change makes the sourcet type names clearer and more specific.

For instance there are now four possible source types for events
coming from the Activity Service API. The events data itself for each
event did not contain a property that specific what kind of event it
was. The new source type names give users a top level peice of data
they can use to target specific kinds of events.