### PR TITLE
(PIE-477) Changed $token to $splunk_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It is possible to only include data in reports based on specific conditions (Pup
 To enable this module:
   - Classify your Puppet Servers with the splunk_hec class
   - Set the `url` parameter which refers to your Splunk url along with the token provided by Splunk
-  - Set the `token` parameter which will be the HEC token you create in Splunk.
+  - Set the `splunk_token` parameter which will be the HEC token you create in Splunk.
   - Set the `enable_reports` to true
 
 This module sends data to Splunk by modifying your report processor settings and indirector routes.yaml.
@@ -69,7 +69,7 @@ When complete the hec token should look something like this\
         ```
         enable_reports = true
         manage_routes = true
-        token = something like F5129FC8-7272-442B-983C-203F013C1948
+        splunk_token = something like F5129FC8-7272-442B-983C-203F013C1948
         url = something like https://splunk-8.splunk.internal:8088/services/collector
         include_api_collection = true
         ```

--- a/Rakefile
+++ b/Rakefile
@@ -204,7 +204,7 @@ namespace :acceptance do
   task :ci_run_tests do
     begin
       Rake::Task['acceptance:setup'].invoke
-      Rake::Task['acceptance:run_tests'].invoke 
+      Rake::Task['acceptance:run_tests'].invoke
     ensure
       Rake::Task['acceptance:tear_down'].invoke
     end

--- a/docs/custom_installation.md
+++ b/docs/custom_installation.md
@@ -3,7 +3,7 @@
 
 __If you are installing this module using a control-repo, you must have splunk_hec in your production environment's Puppetfile so the puppetserver process can load the libraries it needs properly. You can then create a feature branch to enable them and test the configuration, but the libraries must be in production otherwise the feature branch won't work as expected. If your puppetserver is in a different environment, please add this module to the Puppetfile in that environment as well.__
 
-The steps below will help install and troubleshoot the report processor on a single Puppet Master, including manual steps to configure a puppet-server, and to use the included splunk_hec class. Because one is modifying production machines, these steps allow you to validate your settings before deploying the changes live. See the tl,dr; instructions for 
+The steps below will help install and troubleshoot the report processor on a single Puppet Master, including manual steps to configure a puppet-server, and to use the included splunk_hec class. Because one is modifying production machines, these steps allow you to validate your settings before deploying the changes live. See the tl,dr; instructions for
 
 1. Install the Puppet Report Viewer Addon in Splunk. This will import the needed sourcetypes to configure Splunk's HTTP Endpoint Collector (HEC) and provide a dashboard that will show the reports once they are sent to Splunk.
 
@@ -20,7 +20,7 @@ The steps below will help install and troubleshoot the report processor on a sin
   ```
 ---
 "url" : "https://splunk-dev.testing.local:8088/services/collector"
-"token" : "13311780-EC29-4DD0-A796-9F0CDC56F2AD"
+"splunk_token" : "13311780-EC29-4DD0-A796-9F0CDC56F2AD"
 ```
 (Note: If HA is enabled you will need to ensure these settings exist in each master. This is often done through the PE HA Replica node group.)
 
@@ -28,12 +28,12 @@ The steps below will help install and troubleshoot the report processor on a sin
 
 7. If configured properly the Puppet Report Viewer app in Splunk will show 1 node in the Overview tab.
 
-8. Now it is time to roll these settings out to the fleet of to the Puppet Masters in the installation. For Puppet Enterprise users: 
+8. Now it is time to roll these settings out to the fleet of the Puppet Masters in the installation. For Puppet Enterprise users:
 	- Navigate to Classification -> PE Infrastructure -> PE Master
 	- Select Configuration
 	- Press Refresh to ensure the splunk_hec class is loaded
 	- Add new class `splunk_hec`
-	- From the `Parameter name` select atleast `url` and `token` and provide the same attributes from the testing configuration file
+	- From the `Parameter name` select at least `url` and `splunk_token` and provide the same attributes from the testing configuration file
 	- Optionally set `enable_reports` to `true` if there isn't another component managing the servers reports setting, otherwise manually add `splunk_hec` to the settings as described in the manual steps. Note that if `enable_reports` is set to `true`, then you can have the module automatically add the `splunk_hec` report processor to the servers reports setting by setting the `reports` parameter to the empty string, `''`.
 	- Commit changes and run Puppet. It is best to navigate to the PE Certificate Authority Classification gorup and run Puppet there first, before running Puppet on the remaining machines
 

--- a/docs/troubleshooting_and_verification.md
+++ b/docs/troubleshooting_and_verification.md
@@ -31,7 +31,7 @@ Facts enabled properly using the module:
 To verify the reports are in Splunk properly, search all indexes for the source type 'puppet:summary' for reports, 'puppet:facts' for facts:
 `index=* sourcetype=puppet:summary` and `index=* sourcetype=puppet:facts`
 
-The number of events corresponds to the number of Puppet runs that have occured during that time period, not number of hosts. To verify all hosts in an environment have submitted facts/reports, one will need to dedup the events by host to get an accurate count, this is only worth doing after the module has been deployed for atleast an hour (or longer, depending on the Puppet run interval set in the environment). In the Splunk search view, set the time window to the last 60 minutes and use the following search, the resulting Event Count will match the number of nodes in the Puppet Enterprise console:
+The number of events corresponds to the number of Puppet runs that have occured during that time period, not number of hosts. To verify all hosts in an environment have submitted facts/reports, one will need to dedup the events by host to get an accurate count, this is only worth doing after the module has been deployed for at least an hour (or longer, depending on the Puppet run interval set in the environment). In the Splunk search view, set the time window to the last 60 minutes and use the following search, the resulting Event Count will match the number of nodes in the Puppet Enterprise console:
 `index=* sourcetype=puppet:summary | dedup host`
 
 If you are using multiple PE consoles (ie, multiple Puppet Enterprise installations), you will need to add an additional filter by pe_console value:

--- a/examples/splunk_hec.yaml
+++ b/examples/splunk_hec.yaml
@@ -1,5 +1,5 @@
 # managed by puppet
 ---
 "url" : "https://splunk-dev.testing.local:8088/services/collector"
-"token" : "13311780-EC29-4DD0-A796-9F0CDC56F2AD"
+"splunk_token" : "13311780-EC29-4DD0-A796-9F0CDC56F2AD"
 "pe_console": "puppetdb.foo.bar.com"

--- a/files/splunk_hec_collect_api_events.rb
+++ b/files/splunk_hec_collect_api_events.rb
@@ -56,7 +56,7 @@ def process_response(body, total, settings, index_file, source_type, splunk_clie
   events_json = transform(body, settings['pe_console'], source_type)
   store_index(body.empty? ? 0 : total, index_file)
 
-  response = splunk_client.post_request('/services/collector', events_json, { Authorization: "Splunk #{settings['token']}" }, use_raw_body: true)
+  response = splunk_client.post_request('/services/collector', events_json, { Authorization: "Splunk #{settings['splunk_token']}" }, use_raw_body: true)
   raise "Failed to POST to the splunk server [#{response.error!}]" unless response.code == '200'
   true
 end

--- a/lib/puppet/util/splunk_hec.rb
+++ b/lib/puppet/util/splunk_hec.rb
@@ -48,7 +48,7 @@ module Puppet::Util::Splunk_hec
     source_type = body['sourcetype'].split(':')[1]
     token_name = "token_#{source_type}"
     http = create_http(source_type)
-    token = settings[token_name] || settings['token'] || raise(Puppet::Error, 'Must provide token parameter to splunk class')
+    token = settings[token_name] || settings['splunk_token'] || raise(Puppet::Error, 'Must provide token parameter to splunk class')
     req = Net::HTTP::Post.new(@uri.path.to_str)
     req.add_field('Authorization', "Splunk #{token}")
     req.add_field('Content-Type', 'application/json')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,7 +5,7 @@
 # processor by setting reports to '', the empty string.
 class splunk_hec (
   String $url,
-  String $token,
+  String $splunk_token,
   Array $collect_facts = ["dmi","disks","partitions","processors","networking"],
   Boolean $enable_reports = false,
   Boolean $record_event = false,

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -29,7 +29,7 @@ describe 'Verify the minimum install' do
         }
         class { 'splunk_hec':
           url => 'notanendpoint/nicetry',
-          token => '',
+          splunk_token => '',
           record_event => true,
           include_api_collection = true,
         }
@@ -46,7 +46,7 @@ describe 'Verify the minimum install' do
         }
         class { 'splunk_hec':
           url                    => 'notanendpoint/nicetry',
-          token                  => '',
+          splunk_token                  => '',
           record_event           => true,
           pe_username            => 'admin',
           pe_console             => 'localhost',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -58,7 +58,7 @@ describe 'splunk_hec' do
   let(:params) do
     {
       url: 'foo_url',
-      token: 'foo_token',
+      splunk_token: 'foo_token',
       pe_username: 'user',
       pe_password: RSpec::Puppet::Sensitive.new('password'),
       pe_console: 'console',

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -68,7 +68,7 @@ def standard_manifest
     class { 'splunk_hec':
       url                    => "http://#{master.uri}:8088/services/collector/event",
       pe_console             => "#{master.uri}",
-      token                  => "abcd1234",
+      splunk_token           => "abcd1234",
       pe_username            => "admin",
       pe_password            => Sensitive('pie'),
       enable_reports         => true,

--- a/spec/support/acceptance/site.pp
+++ b/spec/support/acceptance/site.pp
@@ -5,7 +5,7 @@ node default {
 
   class { 'splunk_hec':
     url                    => 'http://localhost:8088/services/collector/event',
-    token                  => 'abcd1234',
+    splunk_token           => 'abcd1234',
     pe_console             => 'https://localhost',
     record_event           => true,
     pe_username            => 'admin',

--- a/spec/support/acceptance/splunk/default.yml
+++ b/spec/support/acceptance/splunk/default.yml
@@ -1,6 +1,6 @@
 ---
 # This file is used by the Splunk container to configure settings that would
-# typically be set in the web interface. 
+# typically be set in the web interface.
 # https://splunk.github.io/docker-splunk/ADVANCED.html
 retry_num: 100
 splunk:

--- a/spec/support/acceptance/splunk_hec.yaml
+++ b/spec/support/acceptance/splunk_hec.yaml
@@ -1,5 +1,5 @@
 ---
 "url" : "http://localhost:8088/services/collector/event"
-"token" : "abcd1234"
+"splunk_token" : "abcd1234"
 "enable_reports" : "true"
 "manage_routes" : "true"

--- a/templates/splunk_hec.yaml.epp
+++ b/templates/splunk_hec.yaml.epp
@@ -1,7 +1,7 @@
 # managed by puppet
 ---
 "url" : "<%= $splunk_hec::url %>"
-"token" : "<%= $splunk_hec::token %>"
+"splunk_token" : "<%= $splunk_hec::splunk_token %>"
 "facts" :
 <% $splunk_hec::collect_facts.each |$fact| {-%>
         - <%= $fact %>


### PR DESCRIPTION
Changed $token to $splunk token for clarity because there is also
a $pe_token parameter.