### PR TITLE
(MAINT) Improve acceptance tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,17 +30,9 @@ GetText/DecorateString:
   - spec/**/*
 RSpec/BeforeAfterAll:
   Description: Beware of using after(:all) as it may cause state to leak between tests.
-    A necessary evil in acceptance testing. Disabled here because there is setup that
-    needs to be done before all of the examples in the context but it would be wasteful
-    to do that set up for each example in the context.
+    A necessary evil in acceptance testing.
   Exclude:
   - spec/acceptance/**/*.rb
-  Enabled: false
-RSpec/InstanceVariable:
-  Description: Can be dangerous as it can cause state to leak across tests. In this case
-    we need the state to leak deliberately from the before blocks into the examples
-    and then still be usable in the after blocks.
-  Enabled: false
 RSpec/HookArgument:
   Description: Prefer explicit :each argument, matching existing module's style
   EnforcedStyle: each

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -8,7 +8,7 @@ require 'support/acceptance/shared_context'
 require 'support/acceptance/shared_examples'
 
 describe 'Verify the minimum install' do
-  describe 'with a basic test' do
+  context 'with a basic test' do
     it 'Sets up the pe-puppetserver service and splunk_hec class' do
       apply_manifest(default_manifest, catch_failures: true)
     end
@@ -35,15 +35,17 @@ describe 'Verify the minimum install' do
     end
   end
 
-  describe 'Collect events from PE and sends to the splunk endpoint' do
+  context 'Send events from PE using username/pass auth' do
     include_context 'event collection setup', :default_manifest
 
-    include_examples 'collects and pushed API results', :without_pe_token_key
+    include_examples 'configuration tests', :without_pe_token_key
+    include_examples 'collect and push API results'
   end
 
-  describe 'Collect events from PE using token authentication' do
+  context 'Send events from PE using token authentication' do
     include_context 'event collection setup', :splunk_token_manifest
 
-    include_examples 'collects and pushed API results', :without_pe_password_key
+    include_examples 'configuration tests', :without_pe_password_key
+    include_examples 'collect and push API results'
   end
 end

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -10,6 +10,9 @@ include PuppetLitmus
 # Silence warnings that a backend is not set.
 set :backend, :exec
 
+# Set the number of tasks that should be invoked and then sent to splunka as events
+TASK_COUNT = 5
+
 RSpec.configure do |config|
   include TargetHelpers
 

--- a/spec/support/acceptance/shared_examples.rb
+++ b/spec/support/acceptance/shared_examples.rb
@@ -1,4 +1,4 @@
-RSpec.shared_examples 'collects and pushed API results' do |without_key|
+RSpec.shared_examples 'configuration tests' do |without_key|
   key_name = case without_key
              when :without_pe_password_key
                'pe_password'
@@ -9,27 +9,21 @@ RSpec.shared_examples 'collects and pushed API results' do |without_key|
   it "does not have a #{key_name} setting in the config file" do
     expect(splunk_hec_config.key?(key_name)).to be false
   end
+end
 
-  it 'collects the api results and pushes correctly to splunk' do
-    # Get the total jobs
-    jobs = orchestrator_client.get_jobs(limit: 1)
-
-    # Do a splunk search for the orchestrator sourcetype for the last 5 minutes
-    cmd = %(docker exec splunk_enterprise_1 bash -c "sudo /opt/splunk/bin/splunk search 'sourcetype=\"puppet:jobs\" earliest=\"#{delay}\"' -auth admin:piepiepie")
-
-    result = run_shell(cmd, expect_failures: true)
-    events = result['stdout'].split("\n")
-
-    job_id = jobs.total - 4
-    expect(events.size).to equal(5)
-    events.each do |event_str|
-      event = JSON.parse(event_str)
-      expect(event['options']['task']).to eq('enterprise_tasks::test_connect')
-      expect(event['options']['environment']).to eq('production')
-      expect(event['command']).to eq('task')
-      expect(event['name'].to_i).to eq(job_id)
-      expect(event['report']['id']).to match %r{/orchestrator/v1/jobs/}
-      job_id += 1
+RSpec.shared_examples 'collect and push API results' do
+  context 'Create and send the events' do
+    include_context 'send and collect events'
+    it 'collects the api results and pushes correctly to splunk' do
+      job_id = jobs_starting_count
+      events.each do |event|
+        expect(event['options']['task']).to eq('enterprise_tasks::test_connect')
+        expect(event['options']['environment']).to eq('production')
+        expect(event['command']).to eq('task')
+        expect(event['name'].to_i).to eq(job_id)
+        expect(event['report']['id']).to match %r{/orchestrator/v1/jobs/}
+        job_id += 1
+      end
     end
   end
 end


### PR DESCRIPTION
Instead of using a time based splunk query to see how many events the
script sent to splunk, we switch to a `last n` events filter and just
test to see if we got the events we expected to get.

Switch from executing `master.run_cmd` five times, call it a single time
and execute a command that does the looping on the remote side.

Remove the need for instance variables and `before(:all)` blocks that
Rubocop doesn't like.