### PR TITLE
(PIE-458) Update Splunk container to pull Report Viewer from Github

### DIFF
--- a/spec/support/acceptance/splunk/docker-compose-local.yml
+++ b/spec/support/acceptance/splunk/docker-compose-local.yml
@@ -10,10 +10,7 @@ services:
       # Report Viewer from Splunkbase.
       # We could alternatively download the packaged app from a location
       # like github for testing.
-      - SPLUNK_APPS_URL=https://splunkbase.splunk.com/app/4413/release/3.0.1/download
-      # TODO: Make a PIE account
-      - SPLUNKBASE_USERNAME=gregsparks
-      - SPLUNKBASE_PASSWORD=2Riboflavin!
+      - SPLUNK_APPS_URL=https://github.com/puppetlabs/TA-puppet-report-viewer/tarball/main
       - SPLUNK_PASSWORD=piepiepie
     volumes:
       # default.yml is a mechanism to load splunk settings that would normally

--- a/spec/support/acceptance/splunk/docker-compose.yml
+++ b/spec/support/acceptance/splunk/docker-compose.yml
@@ -10,10 +10,7 @@ services:
       # Report Viewer from Splunkbase.
       # We could alternatively download the packaged app from a location
       # like github for testing.
-      - SPLUNK_APPS_URL=https://splunkbase.splunk.com/app/4413/release/3.0.1/download
-      # TODO: Make a PIE account
-      - SPLUNKBASE_USERNAME=gregsparkspie
-      - SPLUNKBASE_PASSWORD=5736kKtVRkgFBs4@
+      - SPLUNK_APPS_URL=https://github.com/puppetlabs/TA-puppet-report-viewer/tarball/main
       - SPLUNK_PASSWORD=piepiepie
     volumes:
       # default.yml is a mechanism to load splunk settings that would normally


### PR DESCRIPTION
This updates the splunk default.yaml file that configures the Splunk
container to pull the Report Viewer from Github as a tarball rather than
from Splunkbase.