### PR TITLE
(MAINT) Update PE Version

### DIFF
--- a/spec/support/acceptance/install_pe.sh
+++ b/spec/support/acceptance/install_pe.sh
@@ -3,7 +3,7 @@
 version=`puppet --version`
 
 if [ -z "$version" ]; then
-  PE_RELEASE=2019.8.1
+  PE_RELEASE=2019.8.3
   PE_LATEST=$(curl https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/archives/releases/${PE_RELEASE}/LATEST)
   PE_FILE_NAME=puppet-enterprise-${PE_LATEST}-ubuntu-18.04-amd64
   TAR_FILE=${PE_FILE_NAME}.tar


### PR DESCRIPTION
Updated default PE Version installation from 2019.8.1 to 2019.8.3
This is for the sensitive parameter (in plans) compatibility.