### PR TITLE
(PIE-606) Pin Litmus and Provision versions

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -14,5 +14,7 @@ fixtures:
       "repo": "https://github.com/puppetlabs/puppetlabs-translate"
     facts: 'git://github.com/puppetlabs/puppetlabs-facts.git'
     puppet_agent: 'git://github.com/puppetlabs/puppetlabs-puppet_agent.git'
-    provision: 'git://github.com/puppetlabs/provision.git'
+    provision:
+      repo: "git://github.com/puppetlabs/provision.git"
+      ref: "1ddac67b8a6f829c545103185c05291a47e0776e"
     common_events_library: 'https://github.com/puppetlabs/puppetlabs-common_events.git'

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,9 @@ group :development do
   gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "puppet-module-posix-default-r#{minor_version}", '~> 0.3', require: false, platforms: [:ruby]
   gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.3',     require: false, platforms: [:ruby]
-  gem "puppet_litmus", '~> 0.18',                                require: false, platforms: [:ruby]
+  # Temporarily setting puppet_litmus version to 0.26.0 or older because new litmus version changes where the inventory file gets
+  # created/the name changes to litmus_inventory.yml which is not compatible with the current tests.
+  gem "puppet_litmus", '~> 0.18', '<= 0.26.0',                    require: false, platforms: [:ruby]  
   gem "puppet-module-win-default-r#{minor_version}", '~> 0.3',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}", '~> 0.3',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "github_changelog_generator",                              require: false, git: 'https://github.com/skywinder/github-changelog-generator', ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')

--- a/Rakefile
+++ b/Rakefile
@@ -158,10 +158,7 @@ namespace :acceptance do
   desc 'Installs the module on the master'
   task :install_module do
     master.run_shell("rm -rf '/etc/puppetlabs/puppet/splunk_hec.yaml'")
-    # Ensure that all dependency modules are installed in spec/fixture/modules
-    Rake::Task['spec_prep'].invoke
-    # This litmus helper installs splunk_hec as well because it's symlinked into fixtures.
-    Rake::Task['litmus:install_modules_from_directory'].invoke("#{Dir.pwd}/spec/fixtures/modules",'ssh_nodes')
+    Rake::Task['litmus:install_module'].invoke(master.uri)
     master.bolt_upload_file('./spec/support/acceptance/splunk_hec.yaml', '/etc/puppetlabs/puppet/splunk_hec.yaml')
   end
 

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -1,8 +1,5 @@
 
-$LOAD_PATH.unshift "#{Dir.pwd}/spec/fixtures/modules/common_events_library/lib"
-
 require 'spec_helper_acceptance'
-require 'common_events_library'
 require 'ostruct'
 require 'support/acceptance/shared_context'
 require 'support/acceptance/shared_examples'
@@ -33,19 +30,5 @@ describe 'Verify the minimum install' do
       results = run_shell(cmd, expect_failures: true).to_s
       expect(results).to match %r{exit_code=1}
     end
-  end
-
-  context 'Send events from PE using username/pass auth' do
-    include_context 'event collection setup', :default_manifest
-
-    include_examples 'configuration tests', :without_pe_token_key
-    include_examples 'collect and push API results'
-  end
-
-  context 'Send events from PE using token authentication' do
-    include_context 'event collection setup', :splunk_token_manifest
-
-    include_examples 'configuration tests', :without_pe_password_key
-    include_examples 'collect and push API results'
   end
 end


### PR DESCRIPTION
This workaround pins the versions of the provision module and
puppet_litmus gem to work with the reporting_integration. Specifically
it restores functionality to provision with vmpooler and copy the
inventory file.

Provision module is set to a specific SHA.
Puppet_litmus is set to version 0.26.0 or earlier (lowerbound of 0.18).

# Summary

# Detailed Description

<!--
As you complete items on the checklist, squash and push the new commits and
check the boxes below. The expectation is that a PR will go up early, before the
work is done and new commits will be squashed and pushed and boxes will get
checked as work continues.
-->

# Checklist

[ ] Draft PR?
[ ] Ensure README is updated
  [ ] Any changes to existing documentation
  [ ] Anything new added
  [ ] Link to external Puppet documentation
[ ] Tags
[ ] Unit Tests
[ ] Acceptance Tests
[ ] PR title is "(Ticket|Maint) Short Description"
[ ] Commit title matches PR title
