### PR TITLE
(PIE-286) Fix Time Stamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [Unreleased](https://github.com/puppetlabs/puppetlabs-splunk_hec)
+
+[Current Diff](https://github.com/puppetlabs/puppetlabs-splunk_hec/compare/v0.9.0..main)
+
+## Fixed
+
+- Timestamp now matches timestamp value in the console [#130](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/130)
+
 ## [v0.9.0](https://github.com/puppetlabs/puppetlabs-splunk_hec/tree/v0.9.0) (2021-06-29)
 
 [Full Changelog](https://github.com/puppetlabs/puppetlabs-splunk_hec/compare/v0.8.1...v0.9.0)

--- a/lib/puppet/reports/splunk_hec.rb
+++ b/lib/puppet/reports/splunk_hec.rb
@@ -10,7 +10,7 @@ Puppet::Reports.register_report(:splunk_hec) do
     return 0 if settings['disabled']
     # now we can create the event with the timestamp from the report
 
-    epoch = sourcetypetime(time.iso8601(3))
+    epoch = sourcetypetime(time, metrics['time']['total'])
 
     # pass simple metrics for report processing later
     #  STATES = [:skipped, :failed, :failed_to_restart, :restarted, :changed, :out_of_sync, :scheduled, :corrective_change]
@@ -56,7 +56,7 @@ Puppet::Reports.register_report(:splunk_hec) do
         'puppet_version' => puppet_version,
         'report_format' => report_format,
         'status' => status,
-        'time' => time.iso8601(3),
+        'time' => (time + metrics['time']['total']).iso8601(3),
         'transaction_uuid' => transaction_uuid,
       },
     }

--- a/lib/puppet/util/splunk_hec.rb
+++ b/lib/puppet/util/splunk_hec.rb
@@ -104,8 +104,8 @@ module Puppet::Util::Splunk_hec
   end
 
   # standard function to make sure we're using the same time format our sourcetypes are set to parse
-  def sourcetypetime(timestamp)
-    time = Time.parse(timestamp)
-    '%10.3f' % time.to_f
+  def sourcetypetime(time, total)
+    total = Time.parse((time + metrics['time']['total']).iso8601(3))
+    '%10.3f' % total.to_f
   end
 end

--- a/spec/support/unit/reports/splunk_hec_spec_helpers.rb
+++ b/spec/support/unit/reports/splunk_hec_spec_helpers.rb
@@ -9,7 +9,7 @@ def new_processor
   allow(processor).to receive(:host).and_return 'host'
   allow(processor).to receive(:environment).and_return 'production'
   allow(processor).to receive(:job_id).and_return '1'
-  allow(processor).to receive(:time).and_return(Time.now)
+  allow(processor).to receive(:time).and_return(run_start_time)
   allow(processor).to receive(:metrics).and_return(metrics_hash)
   # The report processor logs all exceptions to Puppet.err. Thus, we mock it out
   # so that we can see them (and avoid false-positives).
@@ -21,10 +21,18 @@ end
 
 def metrics_hash
   {
-    'time'      => { 'total' => 0 },
+    'time'      => { 'total' => 5 },
     'resources' => { 'total' => 0 },
     'changes'   => { 'total' => 0 },
   }
+end
+
+def run_total_time
+  (run_start_time + metrics_hash['time']['total']).iso8601(3)
+end
+
+def epoch_time
+  '%10.3f' % Time.parse(run_total_time).to_f
 end
 
 def default_credentials

--- a/spec/unit/reports/splunk_hec_spec.rb
+++ b/spec/unit/reports/splunk_hec_spec.rb
@@ -5,10 +5,21 @@ describe 'Splunk_hec report processor: miscellaneous tests' do
   let(:settings_hash) { default_settings_hash }
   let(:expected_credentials) { default_credentials }
   let(:facts) { default_facts }
+  let(:run_start_time) { Time.now }
 
   before(:each) do
     mock_settings_file(settings_hash)
     allow(processor).to receive(:facts).and_return(facts)
+  end
+
+  context 'metrics' do
+    it 'sends the correct timestamp' do
+      expect_sent_event do |event|
+        expect(event['time']).to eql(epoch_time)
+        expect(event['event']['time']).to eql(run_total_time)
+      end
+      processor.process
+    end
   end
 
   context 'testing splunk_hec disabling feature' do


### PR DESCRIPTION
Prior to this commit, the time stamp sent to Splunk as the `time`
property was only the time an agent run started.

This change adds the run duration to that property so that the time
stamp matches the time stamp found in the Console.

# Summary

# Detailed Description

<!--
As you complete items on the checklist, squash and push the new commits and
check the boxes below. The expectation is that a PR will go up early, before the
work is done and new commits will be squashed and pushed and boxes will get
checked as work continues.
-->

# Checklist

[ ] Draft PR?
[ ] Ensure README is updated
  [ ] Any changes to existing documentation
  [ ] Anything new added
  [ ] Link to external Puppet documentation
  [ ] Review [Support Playbook](https://confluence.puppetlabs.com/display/SUP/Splunk+HEC+Module+Support+Playbook) for any needed updates
[ ] Tags
[ ] Unit Tests
[ ] Acceptance Tests
[x] PR title is "(Ticket|Maint) Short Description"
[ ] Commit title matches PR title
