### PR TITLE
(PIE-818) Allow Ignore System Certificate Store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file. The format 
 
 [Current Diff](https://github.com/puppetlabs/puppetlabs-splunk_hec/compare/v0.9.2..main)
 
+### Added
+
+- Ignore System CA Certificate Store. [#137](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/137)
+
 ## [v0.9.2](https://github.com/puppetlabs/puppetlabs-splunk_hec/tree/v0.9.2) (2021-08-02)
 
 [Full Changelog](https://github.com/puppetlabs/puppetlabs-splunk_hec/compare/v0.9.1...v0.9.2)

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ class profile::splunk_hec {
 }
 ```
 
+The certificate provided to the `ssl_ca` parameter is a supplement to the system ca certificates store. By default, the Ruby classes that perform certificate validation will attempt to use the system certificates first, and then if the certificate cannot be validated there, it will load the ca file in `ssl_ca`. Occasionally, the system cert store will cause validation errors prior to checking the file at `ssl_ca`. To avoid this you can set `ignore_system_cert_store` to `true`. This will allow the code to use ONLY the file at `ssl_ca` to perform certificate validation.
+
 ## Customized Reporting
 
 As of `0.8.0` and later the report processor can be configured to include [**Logs**](https://puppet.com/blog/which-logs-should-i-check-when-things-go-wrong/) and **Resource Events** along with the existing summary data. Because this data varies between runs and agents in Puppet, it is difficult to predict how much data you will use in Splunk as a result. However, this removes the need for configuring the **Detailed Report Generation** alerts in Splunk to retrieve that information; which may be useful for large installations that need to retrieve a large amount of data. You can now just send the information from Puppet directly.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -57,6 +57,7 @@ The following parameters are available in the `splunk_hec` class:
 * [`pe_console`](#pe_console)
 * [`timeout`](#timeout)
 * [`ssl_ca`](#ssl_ca)
+* [`ignore_system_cert_store`](#ignore_system_cert_store)
 * [`token_summary`](#token_summary)
 * [`token_facts`](#token_facts)
 * [`token_metrics`](#token_metrics)
@@ -170,6 +171,17 @@ Data type: `Optional[String]`
 The name of the ca certification/bundle for ssl validation of the splunk_hec endpoint
 
 Default value: ``undef``
+
+##### <a name="ignore_system_cert_store"></a>`ignore_system_cert_store`
+
+Data type: `Optional[Boolean]`
+
+By default, the certificate provided to the ssl_ca parameter is a supplement
+to the system ca certificate store. If that cert store contains invalid
+certificates, ssl validation could fail. Set this parameter to true to
+ignore those certificates and use only the provided file.
+
+Default value: ``false``
 
 ##### <a name="token_summary"></a>`token_summary`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,11 @@
 #   Timeout limit for for both open and read sessions
 # @param [Optional[String]] ssl_ca
 #   The name of the ca certification/bundle for ssl validation of the splunk_hec endpoint
+# @param [Optional[Boolean]] ignore_system_cert_store
+#   By default, the certificate provided to the ssl_ca parameter is a supplement
+#   to the system ca certificate store. If that cert store contains invalid
+#   certificates, ssl validation could fail. Set this parameter to true to
+#   ignore those certificates and use only the provided file.
 # @param [Optional[String]] token_summary
 #   Corresponds to puppet:summary in the Puppet Report Viewer
 #   When storing summary in a different index than the default token
@@ -83,6 +88,7 @@ class splunk_hec (
   Optional[String] $pe_console                           = $settings::report_server,
   Optional[Integer] $timeout                             = undef,
   Optional[String] $ssl_ca                               = undef,
+  Optional[Boolean] $ignore_system_cert_store            = false,
   Optional[String] $token_summary                        = undef,
   Optional[String] $token_facts                          = undef,
   Optional[String] $token_metrics                        = undef,

--- a/spec/support/acceptance/splunk/default.yml
+++ b/spec/support/acceptance/splunk/default.yml
@@ -16,7 +16,7 @@ splunk:
   http_port: 8000
   hec:
     enable: True
-    ssl: False
+    ssl: false
     port: 8088
     token: abcd1234
   smartstore: null

--- a/templates/splunk_hec.yaml.epp
+++ b/templates/splunk_hec.yaml.epp
@@ -15,6 +15,9 @@
 <% if $splunk_hec::ssl_ca { -%>
 "ssl_ca" : "<%= $splunk_hec::ssl_ca %>"
 <% } -%>
+<% if $splunk_hec::ignore_system_cert_store { -%>
+"ignore_system_cert_store" : "<%= $splunk_hec::ignore_system_cert_store %>"
+<% } -%>
 <% if $splunk_hec::record_event { -%>
 "record_event" : "<%= $splunk_hec::record_event %>"
 <% } -%>


### PR DESCRIPTION
This change allows a user to provide a ca certificate file that
overrides the system trusted certificate store entirely.

Prior to this change, a ca certificate file provided to the `ssl_ca`
parameter was only a supplement to the system certificates store. This
could cause an issue where the system certificate store contained
invalid certificates and would cause certificate validation of the
splunk_hec end point to fail before the provided `ssl_ca` file was
checked.

This change fixes that bug by ensuring that only the provided file is
used for verification.

# Summary

# Detailed Description

<!--
As you complete items on the checklist, squash and push the new commits and
check the boxes below. The expectation is that a PR will go up early, before the
work is done and new commits will be squashed and pushed and boxes will get
checked as work continues.
-->

# Checklist

[ ] Draft PR?
[ ] Ensure README is updated
  [ ] Any changes to existing documentation
  [ ] Anything new added
  [ ] Link to external Puppet documentation
  [ ] Review [Support Playbook](https://confluence.puppetlabs.com/display/SUP/Splunk+HEC+Module+Support+Playbook) for any needed updates
[ ] Tags
[ ] Unit Tests
[ ] Acceptance Tests
[ ] PR title is "(Ticket|Maint) Short Description"
[ ] Commit title matches PR title
