### PR TITLE
(PIE-859) Add PE to test matrix

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -7,6 +7,7 @@ fixtures:
     inifile:
       repo: "puppetlabs/inifile"
       ref: "4.2.0"
+    deploy_pe: 'jarretlavallee/deploy_pe'
   repositories:
     "stdlib":
       "repo": "git://github.com/puppetlabs/puppetlabs-stdlib.git"

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -14,9 +14,11 @@ jobs:
       matrix:
         platform:
           - centos-7
-        collection:
+        puppet_version:
           - puppet6-nightly
           - puppet7-nightly
+          - 2019.8.7
+          - 2019.8.8
 
     env:
       BUILDEVENT_FILE: "../buildevents.txt"
@@ -26,18 +28,18 @@ jobs:
     steps:
       - run: |
           echo 'platform=${{ matrix.platform }}' >> $BUILDEVENT_FILE
-          echo 'collection=${{ matrix.collection }}' >> $BUILDEVENT_FILE
+          echo 'puppet_version=${{ matrix.puppet_version }}' >> $BUILDEVENT_FILE
       - name: "Honeycomb: Start recording"
         uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
         with:
           apikey: ${{ env.HONEYCOMB_WRITEKEY }}
           dataset: ${{ env.HONEYCOMB_DATASET }}
           job-status: ${{ job.status }}
-          matrix-key: ${{ matrix.platform }}-${{ matrix.collection }}
+          matrix-key: ${{ matrix.platform }}-${{ matrix.puppet_version }}
 
       - name: "Honeycomb: start first step"
         run: |
-          echo STEP_ID=${{ matrix.platform }}-${{ matrix.collection }}-1 >> $GITHUB_ENV
+          echo STEP_ID=${{ matrix.platform }}-${{ matrix.puppet_version }}-1 >> $GITHUB_ENV
           echo STEP_START=$(date +%s) >> $GITHUB_ENV
       - name: Checkout Source
         uses: actions/checkout@v2
@@ -62,11 +64,11 @@ jobs:
         if: ${{ always() }}
         run: |
           buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Environment'
-          echo STEP_ID=${{ matrix.platform }}-${{ matrix.collection }}-2 >> $GITHUB_ENV
+          echo STEP_ID=${{ matrix.platform }}-${{ matrix.puppet_version }}-2 >> $GITHUB_ENV
           echo STEP_START=$(date +%s) >> $GITHUB_ENV
       - name: Provision test environment
         run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run splunk_hec::provision_machines' -- bundle exec bolt --modulepath spec/fixtures/modules plan run splunk_hec::provision_machines using='provision_service' image='${{ matrix.platform }}'
+          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run splunk_hec::provision_machines' -- bundle exec bolt --modulepath spec/fixtures/modules plan run splunk_hec::acceptance::provision_machines using='provision_service' image='${{ matrix.platform }}'
           echo ::group::=== REQUEST ===
           cat request.json || true
           echo
@@ -82,7 +84,7 @@ jobs:
           echo INVENTORY_PATH=$FILE >> $GITHUB_ENV
       - name: Install server
         run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run splunk_hec::server_setup' -- bundle exec bolt --modulepath spec/fixtures/modules plan run splunk_hec::server_setup collection='${{ matrix.collection }}' -i ./$INVENTORY_PATH
+          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run splunk_hec::acceptance::server_setup' -- bundle exec bolt --modulepath spec/fixtures/modules plan run splunk_hec::acceptance::server_setup puppet_version='${{ matrix.puppet_version }}' -i ./$INVENTORY_PATH
 
       - name: Install module
         run: |
@@ -101,7 +103,7 @@ jobs:
         run: |
           echo ::group::honeycomb step
           buildevents step $TRACE_ID $STEP_ID $STEP_START 'Deploy test system'
-          echo STEP_ID=${{ matrix.platform }}-${{ matrix.collection }}-3 >> $GITHUB_ENV
+          echo STEP_ID=${{ matrix.platform }}-${{ matrix.puppet_version }}-3 >> $GITHUB_ENV
           echo STEP_START=$(date +%s) >> $GITHUB_ENV
           echo ::endgroup::
 

--- a/plans/acceptance/oss_server_setup.pp
+++ b/plans/acceptance/oss_server_setup.pp
@@ -5,7 +5,7 @@
 #
 # @param [Optional[String]] collection
 #   puppet version collection name
-plan splunk_hec::server_setup(
+plan splunk_hec::acceptance::oss_server_setup(
   Optional[String] $collection = 'puppet7'
 ) {
   # get server

--- a/plans/acceptance/pe_server_setup.pp
+++ b/plans/acceptance/pe_server_setup.pp
@@ -1,0 +1,34 @@
+# @summary Install PE Server
+#
+# Install PE Server
+#
+# @example
+#   pe_event_forwarding::acceptance::pe_server_setup
+plan splunk_hec::acceptance::pe_server_setup(
+  Optional[String] $version = '2019.8.7',
+  Optional[Hash] $pe_settings = {password => 'puppetlabs'}
+) {
+  # machines are not yet ready at time of installing the puppetserver, so we wait 15s
+  $localhost = get_targets('localhost')
+  run_command('sleep 15s', $localhost)
+
+  #identify pe server node
+  $puppet_server =  get_targets('*').filter |$n| { $n.vars['role'] == 'server' }
+
+  # install pe server
+  run_plan(
+    'deploy_pe::provision_master',
+    $puppet_server,
+    'version' => $version,
+    'pe_settings' => $pe_settings
+  )
+
+  $cmd = @("CMD")
+          puppet infra console_password --password=pie
+          echo 'pie' | puppet access login --lifetime 1y --username admin
+          puppet infrastructure tune | sed "s,\\x1B\\[[0-9;]*[a-zA-Z],,g" > /etc/puppetlabs/code/environments/production/data/common.yaml
+          puppet agent -t
+          | CMD
+
+  run_command($cmd, $puppet_server, '_catch_errors' => true)
+}

--- a/plans/acceptance/provision_machines.pp
+++ b/plans/acceptance/provision_machines.pp
@@ -4,7 +4,7 @@
 #   provision service
 # @param [Optional[String]] image
 #   os image
-plan splunk_hec::provision_machines(
+plan splunk_hec::acceptance::provision_machines(
   Optional[String] $using = 'abs',
   Optional[String] $image = 'centos-7-x86_64'
 ) {

--- a/plans/acceptance/server_setup.pp
+++ b/plans/acceptance/server_setup.pp
@@ -1,0 +1,25 @@
+# @summary Install PE Server
+#
+# Install PE Server
+#
+# @example
+#   pe_event_forwarding::acceptance::pe_server
+plan splunk_hec::acceptance::server_setup(
+  Optional[String] $puppet_version = '2019.8.7',
+) {
+  # machines are not yet ready at time of installing the puppetserver, so we wait 15s
+  $localhost = get_targets('localhost')
+  run_command('sleep 15s', $localhost)
+
+  if $puppet_version =~ /puppet/ {
+    run_plan(
+      'splunk_hec::acceptance::oss_server_setup',
+      'collection' => $puppet_version
+    )
+  } else {
+    run_plan(
+      'splunk_hec::acceptance::pe_server_setup',
+      'version' => $puppet_version
+    )
+  }
+}


### PR DESCRIPTION
# Summary
This change adds PE versions to the integration test matrix which was
previously Open Source only.

This is required because we now need to test PE Event forwarding as
well.

# Detailed Description

<!--
As you complete items on the checklist, squash and push the new commits and
check the boxes below. The expectation is that a PR will go up early, before the
work is done and new commits will be squashed and pushed and boxes will get
checked as work continues.
-->

# Checklist

[ ] Draft PR?
[ ] Ensure README is updated
  [ ] Any changes to existing documentation
  [ ] Anything new added
  [ ] Link to external Puppet documentation
  [ ] Review [Support Playbook](https://confluence.puppetlabs.com/display/SUP/Splunk+HEC+Module+Support+Playbook) for any needed updates
[ ] Tags
[ ] Unit Tests
[ ] Acceptance Tests
[ ] PR title is "(Ticket|Maint) Short Description"
[ ] Commit title matches PR title
