### PR TITLE
(MAINT) Change util splunk_hec

### DIFF
--- a/files/splunk_hec.rb
+++ b/files/splunk_hec.rb
@@ -5,20 +5,13 @@ require 'json'
 
 data_path = ARGV[0]
 
-# data_path = '/tmp/splunk_hec'
-
 data = JSON.parse(File.read(data_path))
 
 data_to_send = ''
 
 INDICES.each_key do |index|
   next unless data[index]
-  data_to_send << case index
-                  when 'orchestrator'
-                    extract_jobs(data[index])
-                  else
-                    extract_commits(data[index]['commits'], INDICES[index])
-                  end
+  data_to_send << extract_events(data[index], INDICES[index])
 end
 
 submit_request data_to_send

--- a/spec/acceptance/events_processor_spec.rb
+++ b/spec/acceptance/events_processor_spec.rb
@@ -26,7 +26,6 @@ describe 'Event Forwarding' do
     it 'Successfully sends a job event to splunk' do
       # ensure the indexes.yaml file is created
       puppetserver.run_shell("#{EVENT_FORWARDING_CONFDIR}/collect_api_events.rb")
-
       count = report_count(report)
       expect(count).to be 1
     end

--- a/templates/util_splunk_hec.erb
+++ b/templates/util_splunk_hec.erb
@@ -107,28 +107,16 @@ def sourcetypetime(time, duration = 0)
   '%10.3f' % total.to_f
 end
 
-def extract_jobs(jobs_data)
-  items_collector = []
-  jobs_data['items'].map do |item|
-    items_collector << {
-      'time'       => sourcetypetime(item['created_timestamp']),
-      'host'       => settings['pe_console'],
-      'sourcetype' => INDICES['orchestrator'],
-      'event'      => item
-    }.to_json
-  end
-  "#{items_collector.join("\n")}\n"
-end
-
-def extract_commits(commits, index)
-  commits_collector = []
-  commits.map do |commit|
-    commits_collector << {
-      'time'       => sourcetypetime(commit['timestamp']),
+def extract_events(events_data, index)
+  events_collector = []
+  return unless !events_data['events'].nil?
+  events_data['events'].map do |event|
+    events_collector << {
+      'time'       => sourcetypetime(event['created_timestamp'] || event['timestamp']),
       'host'       => settings['pe_console'],
       'sourcetype' => index,
-      'event'      => commit
+      'event'      => event
     }.to_json
   end
-  "#{commits_collector.join("\n")}\n"
+  "#{events_collector.join("\n")}\n"
 end


### PR DESCRIPTION
Modified util_splunk_hec and splunk_hec in the processors directory for
consistency. Now the processor only calls a function `extract_events`
for all indices (orchestrator and activity APIs).

# Summary

# Detailed Description

<!--
As you complete items on the checklist, squash and push the new commits and
check the boxes below. The expectation is that a PR will go up early, before the
work is done and new commits will be squashed and pushed and boxes will get
checked as work continues.
-->

# Checklist

[ ] Draft PR?
[ ] Ensure README is updated
  [ ] Any changes to existing documentation
  [ ] Anything new added
  [ ] Link to external Puppet documentation
  [ ] Review [Support Playbook](https://confluence.puppetlabs.com/display/SUP/Splunk+HEC+Module+Support+Playbook) for any needed updates
[ ] Tags
[ ] Unit Tests
[ ] Acceptance Tests
[ ] PR title is "(Ticket|Maint) Short Description"
[ ] Commit title matches PR title
