### PR TITLE
(MAINT) Fix deprecation warnings

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -27,7 +27,6 @@ Gemfile:
           - mswin
           - mingw
           - x64_mingw
-      - gem: 'pdk'
 
 .travis.yml:
   delete: true

--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ group :development do
   gem "rspec_junit_formatter",                                     require: false
   gem "rspec-puppet-utils",                                        require: false
   gem "rb-readline", '= 0.5.5',                                    require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "pdk",                                                       require: false
 end
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]


### PR DESCRIPTION
Including the PDK gem in the Gemfile includes JSON pure improperly to
a version that is not compatible with Ruby 2.7

# Summary

# Detailed Description

<!--
As you complete items on the checklist, squash and push the new commits and
check the boxes below. The expectation is that a PR will go up early, before the
work is done and new commits will be squashed and pushed and boxes will get
checked as work continues.
-->

# Checklist

[ ] Draft PR?
[ ] Ensure README is updated
  [ ] Any changes to existing documentation
  [ ] Anything new added
  [ ] Link to external Puppet documentation
  [ ] Review [Support Playbook](https://confluence.puppetlabs.com/display/SUP/Splunk+HEC+Module+Support+Playbook) for any needed updates
[ ] Tags
[ ] Unit Tests
[ ] Acceptance Tests
[ ] PR title is "(Ticket|Maint) Short Description"
[ ] Commit title matches PR title
