### PR TITLE
PIE-889 Add query parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Added
 
 - Forwarding from Non Puppet Server nodes. [#154](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/154)
+- Filtering of event types data. [#156](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/156)
 
  ## [v1.0.1](https://github.com/puppetlabs/puppetlabs-splunk_hec/tree/v1.0.1) (2021-10-04)
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,27 @@ PE Customers can install the [`puppetlabs-pe_event_forwarding`](https://forge.pu
 
 By default the `event_types` parameter is configured to send all event types. You can choose which event types to send by setting this parameter to one or more of `orchestrator`, `rbac`, `classifier`, `pe-console`, or `code-manager`.
 
+### Filtering Event Data
+
+To filter the event data, one can set the following parameters:
+* `orchestrator_data_filter`
+* `rbac_data_filter`
+* `classifier_data_filter`
+* `pe_console_data_filter`
+* `code_manager_data_filter`
+
+The default (no filter set) will send all the data received from the event type. The filters must begin with the top level keys of the event data. One can look at the data in Splunk to see/determine what the top level keys are in the event data.
+
+The format of setting these filters is an array of strings and within the string, you separate the different properties of a single path with a dot `.` and continue till the desired value.
+Here's an example of a correctly constructed filter:
+`['options.scope.nodes', 'report.id', 'environment.name']`
+
+**NOTE:**
+
+* You cannot step into arrays. The result of attempting this will return the selected key containing the array as a key of an empty hash.
+* If a key selected does not exist (ie. `['options.foo']`), it will return the key with a `null` value.
+* If there are two incorrect keys such as `['options.foo.baz']`, it will query only up until the first invalid key and return the first incorrect key as an empty hash.
+
 ### Sending from Non Server Nodes
 
 This feature can be configured to send these events from non server nodes if needed. To do this, on the chosen server:

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -73,6 +73,11 @@ The following parameters are available in the `splunk_hec` class:
 * [`include_resources_corrective_change`](#include_resources_corrective_change)
 * [`summary_resources_format`](#summary_resources_format)
 * [`event_types`](#event_types)
+* [`orchestrator_data_filter`](#orchestrator_data_filter)
+* [`rbac_data_filter`](#rbac_data_filter)
+* [`classifier_data_filter`](#classifier_data_filter)
+* [`pe_console_data_filter`](#pe_console_data_filter)
+* [`code_manager_data_filter`](#code_manager_data_filter)
 * [`events_reporting_enabled`](#events_reporting_enabled)
 
 ##### <a name="url"></a>`url`
@@ -301,6 +306,46 @@ Determines which events should be forwarded to Splunk
 Allowed values are: 'orchestrator','rbac','classifier','pe-console','code-manager'
 
 Default value: `['orchestrator','rbac','classifier','pe-console','code-manager']`
+
+##### <a name="orchestrator_data_filter"></a>`orchestrator_data_filter`
+
+Data type: `Optional[Array]`
+
+Filters the jobs event data
+
+Default value: ``undef``
+
+##### <a name="rbac_data_filter"></a>`rbac_data_filter`
+
+Data type: `Optional[Array]`
+
+Filters the rbac event data
+
+Default value: ``undef``
+
+##### <a name="classifier_data_filter"></a>`classifier_data_filter`
+
+Data type: `Optional[Array]`
+
+Filters the classifier event data
+
+Default value: ``undef``
+
+##### <a name="pe_console_data_filter"></a>`pe_console_data_filter`
+
+Data type: `Optional[Array]`
+
+Filters the pe_console event data
+
+Default value: ``undef``
+
+##### <a name="code_manager_data_filter"></a>`code_manager_data_filter`
+
+Data type: `Optional[Array]`
+
+Filters the code_manager event data
+
+Default value: ``undef``
 
 ##### <a name="events_reporting_enabled"></a>`events_reporting_enabled`
 

--- a/files/splunk_hec.rb
+++ b/files/splunk_hec.rb
@@ -13,7 +13,7 @@ EVENT_SOURCETYPE = INDICES.select { |index| settings['event_types'].include? ind
 
 EVENT_SOURCETYPE.each_key do |index|
   next unless data[index]
-  data_to_send << extract_events(data[index], INDICES[index])
+  data_to_send << extract_events(data[index], INDICES[index], settings["#{index}_data_filter"])
 end
 
 submit_request data_to_send

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -77,6 +77,16 @@
 # @param [Optional[Array]] event_types
 #   Determines which events should be forwarded to Splunk
 #   Allowed values are: 'orchestrator','rbac','classifier','pe-console','code-manager'
+# @param [Optional[Array]] orchestrator_data_filter
+#   Filters the jobs event data
+# @param [Optional[Array]] rbac_data_filter
+#   Filters the rbac event data
+# @param [Optional[Array]] classifier_data_filter
+#   Filters the classifier event data
+# @param [Optional[Array]] pe_console_data_filter
+#   Filters the pe_console event data
+# @param [Optional[Array]] code_manager_data_filter
+#   Filters the code_manager event data
 class splunk_hec (
   String $url,
   String $token,
@@ -106,6 +116,11 @@ class splunk_hec (
   Optional[Boolean] $include_resources_corrective_change = false,
   String $summary_resources_format                       = 'hash',
   Optional[Array] $event_types                           = ['orchestrator','rbac','classifier','pe-console','code-manager'],
+  Optional[Array] $orchestrator_data_filter              = undef,
+  Optional[Array] $rbac_data_filter                      = undef,
+  Optional[Array] $classifier_data_filter                = undef,
+  Optional[Array] $pe_console_data_filter                = undef,
+  Optional[Array] $code_manager_data_filter              = undef,
 ) {
 
   $agent_node = $facts['fqdn'] != $facts['puppet_server']

--- a/spec/acceptance/events_processor_spec.rb
+++ b/spec/acceptance/events_processor_spec.rb
@@ -33,10 +33,13 @@ describe 'Event Forwarding' do
     it 'Sets event properties correctly' do
       data   = report[0]['result']
       event  = JSON.parse(data['_raw'])
-      expect(data['source']).to                eql('http:splunk_hec_token')
-      expect(data['sourcetype']).to            eql('puppet:jobs')
-      expect(event['command']).to              eql('task')
-      expect(event['options']['transport']).to eql('pxp')
+
+      expect(data['source']).to                     eql('http:splunk_hec_token')
+      expect(data['sourcetype']).to                 eql('puppet:jobs')
+      expect(event['options']['scope']['nodes']).to eql([host_name])
+      expect(event['options']['blah']).to           be_nil
+      expect(event['environment']['name']).to       eql('production')
+      expect(event['options']['transport']).to      be_nil
     end
   end
 end

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -76,6 +76,7 @@ def report_dir
 end
 
 def setup_manifest(disabled: false, url: 'http://localhost:8088/services/collector/event', with_event_forwarding: false)
+  manifest = ''
   params = {
     url:            url,
     token:          'abcd1234',
@@ -90,11 +91,14 @@ def setup_manifest(disabled: false, url: 'http://localhost:8088/services/collect
     params[:facts_terminus] = 'yaml'
   end
 
-  params[:events_reporting_enabled] = true if with_event_forwarding
+  if with_event_forwarding
+    manifest << add_event_forwarding
+    params[:events_reporting_enabled] = true
+    params[:orchestrator_data_filter] = ['options.scope.nodes', 'options.scope.blah', 'environment.name']
+  end
 
-  manifest = declare(:class, :splunk_hec, params)
+  manifest << declare(:class, :splunk_hec, params)
   manifest << add_service_resource unless puppet_user == 'pe-puppet'
-  manifest << add_event_forwarding if with_event_forwarding
   manifest
 end
 

--- a/templates/splunk_hec.yaml.epp
+++ b/templates/splunk_hec.yaml.epp
@@ -70,3 +70,34 @@
 "events_reporting_enabled" : "<%= $splunk_hec::events_reporting_enabled %>"
 <% } -%>
 "event_types" : "<%= $splunk_hec::event_types %>"
+<% if $splunk_hec::orchestrator_data_filter { -%>
+"orchestrator_data_filter" :
+<% $splunk_hec::orchestrator_data_filter.each |$subset| {-%>
+        - <%= $subset %>
+<% } -%>
+<% } -%>
+<% if $splunk_hec::rbac_data_filter { -%>
+"rbac_data_filter" :
+<% $splunk_hec::rbac_data_filter.each |$subset| {-%>
+        - <%= $subset %>
+<% } -%>
+<% } -%>
+<% if $splunk_hec::classifier_data_filter { -%>
+"classifier_data_filter" :
+<% $splunk_hec::classifier_data_filter.each |$subset| {-%>
+        - <%= $subset %>
+<% } -%>
+<% } -%>
+<% if $splunk_hec::pe_console_data_filter { -%>
+"pe_console_data_filter" :
+<% $splunk_hec::pe_console_data_filter.each |$subset| {-%>
+        - <%= $subset %>
+<% } -%>
+<% } -%>
+<% if $splunk_hec::code_manager_data_filter { -%>
+"code_manager_data_filter" :
+<% $splunk_hec::code_manager_data_filter.each |$subset| {-%>
+        - <%= $subset %>
+<% } -%>
+<% } -%>
+

--- a/templates/util_splunk_hec.erb
+++ b/templates/util_splunk_hec.erb
@@ -8,6 +8,13 @@ require 'yaml'
 require 'json'
 require 'time'
 
+# Rails has deep merge, but pure ruby does not. So we need to implement it ourselves.
+class ::Hash
+  def deep_merge(second)
+      merger = proc { |key, v1, v2| Hash === v1 && Hash === v2 ? v1.merge(v2, &merger) : v2 }
+      self.merge(second, &merger)
+  end
+end
 
 @confdir  = '/etc/puppetlabs/puppet'
 
@@ -106,16 +113,45 @@ def sourcetypetime(time, duration = 0)
   '%10.3f' % total.to_f
 end
 
-def extract_events(events_data, index)
+def extract_events(events_data, index, selectors)
   events_collector = []
+
   return unless !events_data['events'].nil?
+
   events_data['events'].map do |event|
+    collector = {}
+    data      = {}
+
+    selectors.each do |selector|
+      build_data(collector, event, selector.split('.'))
+      data = data.deep_merge(collector)
+    end unless selectors.nil?
+
     events_collector << {
       'time'       => sourcetypetime(event['created_timestamp'] || event['timestamp']),
       'host'       => settings['pe_console'],
       'sourcetype' => index,
-      'event'      => event
+      'event'      => data.empty? ? event : data
     }.to_json
   end
+
   "#{events_collector.join("\n")}\n"
+end
+
+def build_data(final_data, event, path)
+  if path.count == 1
+    if event[path[0]].nil?
+      puts "ERROR with last FILTER KEY; Check your filter parameter"
+    end
+    final_data[path[0]] = event[path[0]]
+    final_data
+  else
+    begin
+      dig_result          = event.dig(*path[0,1])
+      final_data[path[0]] = {}
+      build_data(final_data[path[0]], dig_result, path[1..-1])
+    rescue => e
+      puts "Potential ERROR with middle FILTER KEY: #{e.backtrace}"
+    end
+  end
 end


### PR DESCRIPTION
Added query parameters for selecting which sub set of data they would
like to get in Splunk.
Allows users to send selective data; only the selected paths in each
category will be sent to Splunk. (Defaulted to sending all data to
Splunk)

# Summary

# Detailed Description

<!--
As you complete items on the checklist, squash and push the new commits and
check the boxes below. The expectation is that a PR will go up early, before the
work is done and new commits will be squashed and pushed and boxes will get
checked as work continues.
-->

# Checklist

[ ] Draft PR?
[ ] Ensure README is updated
  [ ] Any changes to existing documentation
  [ ] Anything new added
  [ ] Link to external Puppet documentation
  [ ] Review [Support Playbook](https://confluence.puppetlabs.com/display/SUP/Splunk+HEC+Module+Support+Playbook) for any needed updates
[ ] Tags
[ ] Unit Tests
[ ] Acceptance Tests
[ ] PR title is "(Ticket|Maint) Short Description"
[ ] Commit title matches PR title
