### PR TITLE
(PIE-929) Provision FIPS Environment

### DIFF
--- a/provision.yaml
+++ b/provision.yaml
@@ -3,3 +3,8 @@ acceptance:
   images: ['ubuntu-1804-x86_64']
   vars: |
     role: server
+fips_acceptance:
+  provisioner: abs
+  images:
+  - redhat-fips-7-x86_64
+  - ubuntu-1804-x86_64

--- a/spec/support/acceptance/helpers.rb
+++ b/spec/support/acceptance/helpers.rb
@@ -54,6 +54,10 @@ module TargetHelpers
   end
   module_function :splunk_instance
 
+  def splunk_node
+    target('Splunk Node', 'acceptance:setup_splunk_instance', 'splunk_node')
+  end
+
   def target(name, setup_task, role)
     @targets ||= {}
 

--- a/spec/support/acceptance/start_splunk_instance.sh
+++ b/spec/support/acceptance/start_splunk_instance.sh
@@ -28,7 +28,7 @@ function start_splunk() {
   echo 'Splunk container start succeeded.'
 }
 
-function centos_install_docker() {
+function yum_install_docker() {
   yum install -y yum-utils
   yum-config-manager \
     --add-repo \
@@ -55,15 +55,15 @@ function wait_for_compose() {
   done
 }
 
-CENTOS=$(cat /etc/*-release | grep CentOS)
+YUM=$(cat /etc/*-release | grep 'CentOS\|rhel')
 
 nodocker=$(which docker 2>&1 | grep "no docker")
 status=$?
 
 if [ ! -z "$nodocker" ]
 then
-  if [ ! -z "$CENTOS" ]; then
-    centos_install_docker
+  if [ ! -z "$YUM" ]; then
+    yum_install_docker
   fi
 else
   apt-get -qq update -y 1>&- 2>&-


### PR DESCRIPTION
When the `PROVISION_LIST` environment variable is set to
'fips_acceptance', the rake tasks should know how to set up a FIPS
testing environment. This setup needs to provision a FIPS enabled OS
image, install FIPS enabled PE, provision a non fips OS image and
run the Splunk container image from that machine, and correctly
build an inventory file to allow proper targeting of the two servers.

# Summary

# Detailed Description

<!--
As you complete items on the checklist, squash and push the new commits and
check the boxes below. The expectation is that a PR will go up early, before the
work is done and new commits will be squashed and pushed and boxes will get
checked as work continues.
-->

# Checklist

[ ] Draft PR?
[ ] Ensure README is updated
  [ ] Any changes to existing documentation
  [ ] Anything new added
  [ ] Link to external Puppet documentation
  [ ] Review [Support Playbook](https://confluence.puppetlabs.com/display/SUP/Splunk+HEC+Module+Support+Playbook) for any needed updates
[ ] Tags
[ ] Unit Tests
[ ] Acceptance Tests
[ ] PR title is "(Ticket|Maint) Short Description"
[ ] Commit title matches PR title
