### PR TITLE
(SUP-2728) Add pe_console field to metric events

### DIFF
--- a/lib/puppet/application/splunk_hec.rb
+++ b/lib/puppet/application/splunk_hec.rb
@@ -45,6 +45,7 @@ class Puppet::Application::Splunk_hec < Puppet::Application
         event = event_template.clone
         event['host'] = name
         event['event'] = content[serv.to_s]
+        event['event']['pe_console'] = pe_console
         event['event']['pe_service'] = serv.to_s
         Puppet.info 'Submitting metrics to Splunk'
         submit_request(event)


### PR DESCRIPTION
The host field in Splunk for metrics data provides a formatted hostname replacing dots with dashes. In an attempt to utilize the pe_console field from facts data against the host field in the metrics data I discovered the mismatch between the host fields.

Adding the pe_console field to metric events allowed me to properly sort the hosts by the pe_console they are connected to.