### PR TITLE
(PIE-941) Detect running on non master node

### DIFF
--- a/lib/facter/splunk_hec_agent_only_node.rb
+++ b/lib/facter/splunk_hec_agent_only_node.rb
@@ -1,0 +1,10 @@
+# This code is in a fact because attempting to get these values and
+# compare them using any other method, like just using the $settings variable
+# makes unit testing with rspec-puppet extremely difficult. Putting this code
+# here makes it easy to choose the value to assign for this fast and therefore
+# easier to code different code paths through the init.pp file.
+Facter.add(:splunk_hec_agent_only_node) do
+  setcode do
+    Puppet.settings['server'] != Puppet.settings['node_name_value']
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -125,7 +125,7 @@ class splunk_hec (
   Optional[Array] $code_manager_data_filter              = undef,
 ) {
 
-  $agent_node = $facts['fqdn'] != $facts['puppet_server']
+  $agent_node = $facts['splunk_hec_agent_only_node']
 
   # Account for the differences in Puppet Enterprise and Open Source and Agent
   if $agent_node {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -10,6 +10,10 @@ describe 'splunk_hec' do
     Service { 'pe-puppetserver':
     }
 
+    # Define the puppetserver service
+    Service { 'puppetserver':
+    }
+
     # pe_ini_setting is a PE-only resource. Since PE modules are private, we
     # make the resource a defined type for the unit tests. Note that we still
     # have to use pe_ini_setting instead of ini_setting for backwards compatibility.
@@ -62,13 +66,16 @@ describe 'splunk_hec' do
 
   let(:confdir) { Dir.pwd }
   let(:event_forwarding_base) { "#{confdir}/pe_event_forwarding/processors.d" }
+  let(:facts) do
+    {
+      splunk_hec_agent_only_node: false
+    }
+  end
 
   context 'on a server node' do
     let(:facts) do
       {
-        splunk_hec_is_pe: true,
-        fqdn:             'myhost.example.com',
-        puppet_server:    'myhost.example.com'
+        splunk_hec_is_pe: true
       }
     end
 
@@ -157,18 +164,16 @@ describe 'splunk_hec' do
   end
 
   context 'on an agent node' do
-    let(:facts) do
-      {
-        fqdn:          'myagent.example.com',
-        puppet_server: 'mypuppetserver.example.com'
-      }
-    end
-
     # enable_reports should always be false on an agent node.
     let(:params) do
       p = super()
       p['enable_reports'] = false
       p
+    end
+    let(:facts) do
+      {
+        splunk_hec_agent_only_node: true
+      }
     end
 
     context 'events_reporting not enabled' do


### PR DESCRIPTION
The previous method in use for detecting when a node is an agent only
node had a bug. The fact being used to figure out the name of the server
node was not always present.

This method is more reliable and it's easier to unit test.

# Summary

# Detailed Description

<!--
As you complete items on the checklist, squash and push the new commits and
check the boxes below. The expectation is that a PR will go up early, before the
work is done and new commits will be squashed and pushed and boxes will get
checked as work continues.
-->

# Checklist

[ ] Draft PR?
[ ] Ensure README is updated
  [ ] Any changes to existing documentation
  [ ] Anything new added
  [ ] Link to external Puppet documentation
  [ ] Review [Support Playbook](https://confluence.puppetlabs.com/display/SUP/Splunk+HEC+Module+Support+Playbook) for any needed updates
[ ] Tags
[ ] Unit Tests
[ ] Acceptance Tests
[ ] PR title is "(Ticket|Maint) Short Description"
[ ] Commit title matches PR title
