### PR TITLE
(MAINT) Fix Release Prep

### DIFF
--- a/.github/workflows/release_prep.yml
+++ b/.github/workflows/release_prep.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       module_version:
+        description: 'The new version you would like to release'
         required: true
 
 jobs:
@@ -44,11 +45,15 @@ jobs:
           echo "COMMIT_BODY_NOTE=$(echo -n "${commit_body} **Note:** You can use https://github.com/${{ github.repository }}/compare/${{ steps.most_recent_tag.outputs.tag  }}...${{ env.GITHUB_BRANCH }} to see all the new commits that have landed since the previous release.")" >> $GITHUB_ENV
         fi
 
+    - name: Release Prep
+      uses: docker://puppet/pdk:nightly
+      with:
+        args: 'release prep --version=${{ github.event.inputs.module_version }} --skip-changelog'
+
     - name: Generate the release prep commit
       run: |
         git checkout -b release_prep
-        bundle install --with release_prep
-        pdk release prep --version=${{ github.event.inputs.module_version }} --skip-changelog
+        bundle install
         git add .
         git -c user.name=${{ github.actor }} -c user.email=${{ github.actor }}@users.noreply.github.com commit -m "${{ env.COMMIT_TITLE }}" -m "${{ env.COMMIT_BODY_MAIN }}" -m '' -m '${{ env.COMMIT_BODY_NOTE }}'
         git push --set-upstream origin release_prep --force


### PR DESCRIPTION
We didn't realize when we removed the PDK gem from the Gemfile that this
workflow was the reason it was reason it was needed.

This change switches to using the PDK container so it doesn't have to be
installed.

# Summary

# Detailed Description

<!--
As you complete items on the checklist, squash and push the new commits and
check the boxes below. The expectation is that a PR will go up early, before the
work is done and new commits will be squashed and pushed and boxes will get
checked as work continues.
-->

# Checklist

[ ] Draft PR?
[ ] Ensure README is updated
  [ ] Any changes to existing documentation
  [ ] Anything new added
  [ ] Link to external Puppet documentation
  [ ] Review [Support Playbook](https://confluence.puppetlabs.com/display/SUP/Splunk+HEC+Module+Support+Playbook) for any needed updates
[ ] Tags
[ ] Unit Tests
[ ] Acceptance Tests
[ ] PR title is "(Ticket|Maint) Short Description"
[ ] Commit title matches PR title
