### PR TITLE
(MAINT) Update ruby versions for github actions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         check: ['syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop parallel_spec']
-        ruby_version: [2.5.x]
+        ruby_version: [2.7.x]
         puppet_gem_version: [~> 6.0]
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/release_prep.yml
+++ b/.github/workflows/release_prep.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.5.3
+        ruby-version: 2.7
 
     - name: Update Rubygems
       run: gem update --system 3.1.0


### PR DESCRIPTION
Using Ruby 2.5.x caused bundle install errors during release prep.
Since 2.5.x is no longer supported by Puppet there's not reason to keep
using it.

# Summary

# Detailed Description

<!--
As you complete items on the checklist, squash and push the new commits and
check the boxes below. The expectation is that a PR will go up early, before the
work is done and new commits will be squashed and pushed and boxes will get
checked as work continues.
-->

# Checklist

[ ] Draft PR?
[ ] Ensure README is updated
  [ ] Any changes to existing documentation
  [ ] Anything new added
  [ ] Link to external Puppet documentation
  [ ] Review [Support Playbook](https://confluence.puppetlabs.com/display/SUP/Splunk+HEC+Module+Support+Playbook) for any needed updates
[ ] Tags
[ ] Unit Tests
[ ] Acceptance Tests
[ ] PR title is "(Ticket|Maint) Short Description"
[ ] Commit title matches PR title
