### PR TITLE
(PIE-959) Agent Only Node Fact Broken

### DIFF
--- a/lib/facter/splunk_hec_agent_only_node.rb
+++ b/lib/facter/splunk_hec_agent_only_node.rb
@@ -5,6 +5,6 @@
 # easier to code different code paths through the init.pp file.
 Facter.add(:splunk_hec_agent_only_node) do
   setcode do
-    Puppet.settings['server'] != Puppet.settings['node_name_value']
+    Dir['/lib/systemd/system/*puppetserver.service'].empty?
   end
 end


### PR DESCRIPTION
The implementation of the fact `splunk_hec_agent_only_node` was flawed.
It attempted to see if there was a difference between the `server` fact
and the current nodes name. It turns out this is not a good method
because in a multi master environment, a node might have a different
name from the `server` fact, but it is still a server node that might
run report processors.

This implementation looks at the services configured on the machine to
determine if a puppetserver service has been registered.

# Summary

# Detailed Description

<!--
As you complete items on the checklist, squash and push the new commits and
check the boxes below. The expectation is that a PR will go up early, before the
work is done and new commits will be squashed and pushed and boxes will get
checked as work continues.
-->

# Checklist

[ ] Draft PR?
[ ] Ensure README is updated
  [ ] Any changes to existing documentation
  [ ] Anything new added
  [ ] Link to external Puppet documentation
  [ ] Review [Support Playbook](https://confluence.puppetlabs.com/display/SUP/Splunk+HEC+Module+Support+Playbook) for any needed updates
[ ] Tags
[ ] Unit Tests
[ ] Acceptance Tests
[ ] PR title is "(Ticket|Maint) Short Description"
[ ] Commit title matches PR title
