### PR TITLE
(PIE-792) Send all facts to Splunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file. The format 
 
 [Current Diff](https://github.com/puppetlabs/puppetlabs-splunk_hec/compare/v1.1.0..main)
 
+### Added
+
+- Ability to collect all facts against a blocklist. [#170](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/170)
+
 ## [v1.1.0](https://github.com/puppetlabs/puppetlabs-splunk_hec/tree/v1.1.0) (2021-11-09)
 
 [Full Changelog](https://github.com/puppetlabs/puppetlabs-splunk_hec/compare/v1.0.1..v1.1.0)

--- a/README.md
+++ b/README.md
@@ -7,14 +7,15 @@
 3. [Installation](#installation)
 4. [Custom Installation](#custom-installation)
 5. [SSL Configuration](#ssl-configuration)
-6. [Customized Reporting](#customized-reporting)
-7. [Tasks](#tasks)
-8. [Advanced Settings](#advanced-settings)
-9. [FIPS Mode](#fips-mode)
-10. [Advanced Topics](#advanced-topics)
-11. [Known Issues](#known-issues)
-12. [Breaking Changes](#breaking-changes)
-13. [Release Process](#release-process)
+6. [Fact Configuration](#fact-configuration)
+7. [Customized Reporting](#customized-reporting)
+8. [Tasks](#tasks)
+9. [Advanced Settings](#advanced-settings)
+10. [FIPS Mode](#fips-mode)
+11. [Advanced Topics](#advanced-topics)
+12. [Known Issues](#known-issues)
+13. [Breaking Changes](#breaking-changes)
+14. [Release Process](#release-process)
 
 ## Overview
 
@@ -215,6 +216,17 @@ class profile::splunk_hec {
 ```
 
 The certificate provided to the `ssl_ca` parameter is a supplement to the system ca certificates store. By default, the Ruby classes that perform certificate validation will attempt to use the system certificates first, and then if the certificate cannot be validated there, it will load the ca file in `ssl_ca`. Occasionally, the system cert store will cause validation errors prior to checking the file at `ssl_ca`. To avoid this you can set `ignore_system_cert_store` to `true`. This will allow the code to use ONLY the file at `ssl_ca` to perform certificate validation.
+
+## Fact Configuration
+
+The following parameters are utilized to configure which facts (including custom facts) you would like to send to Splunk:
+
+  * `collect_facts`
+  * `facts_blocklist` (**Optional**)
+
+To configure which facts to collect add the `collect_facts` parameter to the `splunk_hec` class and modify the array of facts presented.
+    * To collect **all facts** available at the time of the Puppet run, add the special value `all.facts` to the `collect_facts` array.
+    * When collecting **all facts**, you can configure the optional parameter `facts_blocklist` with an array of facts that should not be collected.
 
 ## PE Event Forwarding
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -55,6 +55,7 @@ The following parameters are available in the `splunk_hec` class:
 * [`events_reporting_enabled`](#events_reporting_enabled)
 * [`facts_terminus`](#facts_terminus)
 * [`facts_cache_terminus`](#facts_cache_terminus)
+* [`facts_blocklist`](#facts_blocklist)
 * [`reports`](#reports)
 * [`pe_console`](#pe_console)
 * [`timeout`](#timeout)
@@ -95,7 +96,7 @@ The user token
 
 Data type: `Array`
 
-The list of facts that will be collected in the report
+The list of facts that will be collected in the report. To collect all facts available add the special value 'all.facts'.
 
 Default value: `['dmi','disks','partitions','processors','networking']`
 
@@ -154,6 +155,14 @@ Data type: `String`
 Makes sure that the facts get sent to splunk_hec
 
 Default value: `'splunk_hec'`
+
+##### <a name="facts_blocklist"></a>`facts_blocklist`
+
+Data type: `Optional[Array]`
+
+The list of facts that will not be collected in the report
+
+Default value: ``undef``
 
 ##### <a name="reports"></a>`reports`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,7 +13,7 @@
 # @param [String] token
 #   The user token
 # @param [Array] collect_facts
-#   The list of facts that will be collected in the report
+#   The list of facts that will be collected in the report. To collect all facts available add the special value 'all.facts'.
 # @param [Boolean] enable_reports
 #   Adds splunk_hec to the list of report processors
 # @param [Boolean] record_event
@@ -28,6 +28,8 @@
 #   Ensure that facts get saved to puppetdb
 # @param [String] facts_cache_terminus
 #   Makes sure that the facts get sent to splunk_hec
+# @param [Optional[Array]] facts_blocklist
+#   The list of facts that will not be collected in the report
 # @param [Optional[String]] reports
 #   Can specify report processors (other than puppetdb which is default)
 #   Deprecated; should not use (will give warning).
@@ -100,6 +102,7 @@ class splunk_hec (
   Boolean $events_reporting_enabled                      = false,
   String $facts_terminus                                 = 'puppetdb',
   String $facts_cache_terminus                           = 'splunk_hec',
+  Optional[Array] $facts_blocklist                       = undef,
   Optional[String] $reports                              = undef,
   Optional[String] $pe_console                           = $settings::report_server,
   Optional[Integer] $timeout                             = undef,

--- a/templates/splunk_hec.yaml.epp
+++ b/templates/splunk_hec.yaml.epp
@@ -2,11 +2,17 @@
 ---
 "url" : "<%= $splunk_hec::url %>"
 "token" : "<%= $splunk_hec::token %>"
-"facts" :
+"facts.allowlist" :
 <% $splunk_hec::collect_facts.each |$fact| {-%>
         - <%= $fact %>
 <% } -%>
-<% if $splunk_hec::pe_console{ -%>
+<% unless $splunk_hec::facts_blocklist == undef { -%>
+"facts.blocklist" :
+<% [$splunk_hec::facts_blocklist].flatten.each |$fact| { -%>
+        - <%= $fact %>
+<% } -%>
+<% } -%>
+<% if $splunk_hec::pe_console { -%>
 "pe_console" : "<%= $splunk_hec::pe_console %>"
 <% } -%>
 <% if $splunk_hec::timeout { -%>


### PR DESCRIPTION
# Summary

This PR adds the ability to collect all facts (including custom facts) by adding the special value `all.facts` to the `collect_facts` parameter. With the aforementioned special value configured, the optional `facts_blacklist` will be taken into consideration when collecting facts.

# Detailed Description

  * Updated `lib/puppet/indirector/facts/splunk_hec.rb` to collect all facts when `all.facts` is in the `collect_facts` array.
  * Added optional parameter `facts_blocklist`.
  * Updated `README.md`.
  * Updated `REFERENCE.md`.
  * Updated `CHANGELOG.md`.

# Checklist

[X] Ensure README is updated
  [X] Any changes to existing documentation
  [X] Anything new added
  [X] Link to external Puppet documentation
  [X] Review [Support Playbook](https://confluence.puppetlabs.com/display/SUP/Splunk+HEC+Module+Support+Playbook) for any needed updates
[X] Acceptance Tests
[X] PR title is "(Ticket|Maint) Short Description"
[X] Commit title matches PR title
