### PR TITLE
(MAINT) GH security move from git to https

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,13 +9,10 @@ fixtures:
       ref: "4.2.0"
     deploy_pe: 'jarretlavallee/deploy_pe'
   repositories:
-    "stdlib":
-      "repo": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    "translate":
-      "repo": "https://github.com/puppetlabs/puppetlabs-translate"
-    facts: 'git://github.com/puppetlabs/puppetlabs-facts.git'
-    puppet_agent: 'git://github.com/puppetlabs/puppetlabs-puppet_agent.git'
-    provision: "git://github.com/puppetlabs/provision.git"
-    puppet_conf:
-      repo: 'https://github.com/puppetlabs/puppet_conf.git'
-    pe_event_forwarding: 'https://github.com/puppetlabs/puppetlabs-pe_event_forwarding.git'
+    stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib'
+    translate: 'https://github.com/puppetlabs/puppetlabs-translate'
+    facts: 'https://github.com/puppetlabs/puppetlabs-facts'
+    puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent'
+    provision: 'https://github.com/puppetlabs/provision'
+    puppet_conf: 'https://github.com/puppetlabs/puppet_conf'
+    pe_event_forwarding: 'https://github.com/puppetlabs/puppetlabs-pe_event_forwarding'


### PR DESCRIPTION
# Summary

Per recent changes to [GH security](https://github.blog/2021-09-01-improving-git-protocol-security-github/), updated repo source protocols in `.fixures.yaml`.

# Detailed Description

  * Updated `.fixtures.yaml` to move public repo sources from `git` to `https` protocol.

# Checklist

[X] PR title is "(Ticket|Maint) Short Description"
[X] Commit title matches PR title
