### PR TITLE
(MAINT) Fix typos/syntax issues in docs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This module provides three services to Puppet and Splunk users.
 
     For more advanced configuration options including sending reports based on specific conditions see the [Customized Reporting](#customized-reporting) section below.
 
-2. A fact terminus to submit node facts to Splunk. See [Fact Terminus Support](https://github.com/puppetlabs/puppetlabs-splunk_hec/blob/v0.8.1/docs/fact_terminus_support.md) for details.
+2. A fact terminus to submit node facts to Splunk. See [Fact Terminus Support](https://github.com/puppetlabs/puppetlabs-splunk_hec/blob/main/docs/fact_terminus_support.md) for details.
 
 3. A PE Event Forwarding processor for sending data received from the [PE Event Forwarding](https://forge.puppet.com/modules/puppetlabs/pe_event_forwarding) module to Splunk. This data can include the details of Task and Plan executions that were initiated by the Puppet Orchestrator (clicking execute task|plan from the console or puppet command line), or it can be events from rbac, the node classifier, the console, or code-manager. To enable this feature, after the PE Event Forwarding module has been installed, set the `events_reporting_enabled` parameter on the `splunk` class to `true`.
 
@@ -46,16 +46,16 @@ There are two Tasks included in this module, `splunk_hec:bolt_apply` and `splunk
 * Puppet Enterprise (PE) or Open Source Puppet*
 * Splunk
 
-This was tested on PE 2019.8.7, Puppet 6 and Puppet 7, using stock gems of `yaml`, `json`, and `net::https`.
+This was tested on the Puppet Enterprise LTS release, Puppet 6 and Puppet 7, using stock gems of `yaml`, `json`, and `net::https`.
 
-\* While most of this module is PE and Open Source, using the PE Event Forwarding processor is PE only because it gathers data from API's that exist only in Puppet Enterprise.
+* While most of this module is PE and Open Source, using the PE Event Forwarding processor is PE only because it gathers data from API's that exist only in Puppet Enterprise.
 
 ## Installation
 
 Instructions assume you are using Puppet Enterprise. For Open Source Puppet installations please see the [Custom Installation](#custom-installation) section.
 
 1. Install the [Puppet Report Viewer](https://splunkbase.splunk.com/app/4413/) app in Splunk if not already installed.
-    * Please see [Splunk Installation](https://docs.splunk.com/Documentation/Splunk/8.0.3/SearchTutorial/InstallSplunk) if you need to install Splunk.
+    * Please see [Splunk Installation](https://docs.splunk.com/Documentation/Splunk/latest/SearchTutorial/InstallSplunk) if you need to install Splunk.
     * Alternatively you can [install Splunk via Bolt](https://forge.puppet.com/configuration-management/puppetlabs/deploy-splunk-enterprise-in-minutes).
 2. Create an HEC token in Splunk:
   * Navigate to `Settings` > `Data Input` in your Splunk console.
@@ -93,39 +93,39 @@ Instructions assume you are using Puppet Enterprise. For Open Source Puppet inst
 
 ## Source Types
 
-1. puppet:summary
+1. `puppet:summary`
 
     Puppet agent node reports.
 
-2. puppet:facts
+2. `puppet:facts`
 
     Node facts sent by the facts terminus enabled by setting `manage_routes` to true.
 
-3. puppet:jobs
+3. `puppet:jobs`
 
-    Events gathered from the [Puppet Jobs API](https://puppet.com/docs/pe/2019.8/orchestrator_api_jobs_endpoint.html#get_jobs)
+    Events gathered from the [Puppet Jobs API](https://puppet.com/docs/pe/latest/orchestrator_api_jobs_endpoint.html#get_jobs)
 
-The following source types all refer to different types of events gathered from the [Puppet Activities API](https://puppet.com/docs/pe/2021.2/activity_api_events.html#activity-api-v2-get-events)
+The following source types all refer to different types of events gathered from the [Puppet Activities API](https://puppet.com/docs/pe/latest/activity_api_events.html#activity-api-v2-get-events)
 
-4. puppet:activities_rbac
+4. `puppet:activities_rbac`
 
     RBAC events such user login or creating or modifying users and groups.
 
-5. puppet:activities_classifier
+5. `puppet:activities_classifier`
 
     Classifier events such as creating node groups, or modifying the properties of node groups.
 
-6. puppet:activities_console
+6. `puppet:activities_console`
 
     Console events such as requesting Task or Plan runs via the console.
 
-7. puppet:activities_code_manager
+7. `puppet:activities_code_manager`
 
     Code manager events.
 
 ## Custom Installation
 
-> **Please Note**: If you are installing this module using a [`control-repo`](https://puppet.com/docs/pe/2021.2/control_repo.html) you must have `splunk_hec` in your production environment's [`Puppetfile`](https://puppet.com/docs/pe/2019.8/puppetfile.html) so the Puppet Server process can properly load the required libraries. You can then create a feature branch to enable them and test the configuration, but the libraries **must be** in `production`; otherwise the feature branch won't work as expected. If your Puppet Server is in a different environment, please add this module to the `Puppetfile` in that environment as well.
+> **Please Note**: If you are installing this module using a [`control-repo`](https://puppet.com/docs/pe/latest/control_repo.html) you must have `splunk_hec` in your production environment's [`Puppetfile`](https://puppet.com/docs/pe/latest/puppetfile.html) so the Puppet Server process can properly load the required libraries. You can then create a feature branch to enable them and test the configuration, but the libraries **must be** in `production`; otherwise the feature branch won't work as expected. If your Puppet Server is in a different environment, please add this module to the `Puppetfile` in that environment as well.
 
 The steps below will help install and troubleshoot the report processor on a standard Puppet Primary Server; including manual steps to configure compilers (Puppet Servers), and to use the included `splunk_hec` class. Because one is modifying production machines, these steps allow you to validate your settings before deploying the changes live.
 
@@ -133,7 +133,7 @@ The steps below will help install and troubleshoot the report processor on a sta
 
 2. Create a Splunk HEC Token or use an existing one that sends to `main` index and **does not** have acknowledgement enabled. Follow the steps provided by Splunk's [Getting Data In Guide](http://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector) if you are new to HTTP Endpoint Collectors.
 
-3. [Install this Puppet module](https://puppet.com/docs/puppet/7/modules_installing.html) in the environment that your Puppet Servers are using (e.g. `production`).
+3. [Install this Puppet module](https://puppet.com/docs/puppet/latest/modules_installing.html) in the environment that your Puppet Servers are using (e.g. `production`).
 
 4. Run `puppet plugin download` on your Puppet Servers to sync the content. Some users with strict permissions may need to run `umask 022` first.
 
@@ -143,7 +143,7 @@ The steps below will help install and troubleshoot the report processor on a sta
       Could not find terminus splunk_hec for indirection facts
       ```
 
-5. Create `/etc/puppetlabs/puppet/splunk_hec.yaml` (see the [examples directory](https://github.com/puppetlabs/puppetlabs-splunk_hec/blob/v0.8.1/examples/splunk_hec.yaml)), adding your Splunk Server URL to the `url` parameter (e.g. `https://splunk-dev:8088/services/collector`) and HEC Token created during step 2 to the `splunk_token` parameter.
+5. Create `/etc/puppetlabs/puppet/splunk_hec.yaml` (see the [examples directory](https://github.com/puppetlabs/puppetlabs-splunk_hec/blob/main/examples/splunk_hec.yaml)), adding your Splunk Server URL to the `url` parameter (e.g. `https://splunk-dev:8088/services/collector`) and HEC Token created during step 2 to the `splunk_token` parameter.
   * You can add `timeout` as an optional parameter. The **default value** is `1` second for both open and read sessions, so take value x2 for real world use.
   * **PE Only**: Provide the `pe_console` parameter value. This is the FQDN for the PE console, which Splunk can use to lookup further information if the installation utilizes compilers (it is best practice to set this if you're anticipating scaling the installation in the future).
 
@@ -159,7 +159,7 @@ The steps below will help install and troubleshoot the report processor on a sta
 7. If configured properly the Puppet Report Viewer app in Splunk will show 1 node in the `Overview` tab.
 
 8. Now it is time to roll these settings out to the fleet of Puppet Servers in the installation. For PE users:
-  * In the [PE console](https://puppet.com/docs/pe/2021.2/console_accessing.html), navigate to `Node groups` and expand `PE Infrastructure`.
+  * In the [PE console](https://puppet.com/docs/pe/latest/console_accessing.html), navigate to `Node groups` and expand `PE Infrastructure`.
   * Select `PE Master` and navigate to the `Classes` tab.
   * Click **Refresh** to ensure that the `splunk_hec` class is loaded.
   * Add new class `splunk_hec`.
@@ -167,7 +167,7 @@ The steps below will help install and troubleshoot the report processor on a sta
       * Optionally set `enable_reports` to `true` if there isn't another component managing the servers reports setting. Otherwise manually add `splunk_hec` to the settings as described in the [manual steps](#manual-steps) below.
   * Commit changes and run Puppet. It is best to navigate to the `PE Certificate Authority` node group and run Puppet there first, before running Puppet on the remaining nodes.
 
-9. For Inventory support in the Puppet Report Viewer, see [Fact Terminus Support](https://github.com/puppetlabs/puppetlabs-splunk_hec/blob/v0.8.1/docs/fact_terminus_support.md).
+9. For Inventory support in the Puppet Report Viewer, see [Fact Terminus Support](https://github.com/puppetlabs/puppetlabs-splunk_hec/blob/main/docs/fact_terminus_support.md).
 
 #### Manual Steps:
 
@@ -181,7 +181,7 @@ The steps below will help install and troubleshoot the report processor on a sta
     reports = puppetdb,splunk_hec
     ```
 
-  * [Restart the `pe-puppetserver`](https://puppet.com/docs/puppetserver/5.3/restarting.html#:~:text=0%2C%20you%20can%20restart%20Puppet,stopping%20and%20restarting%20the%20process.) process (`puppet-server` for Open Source Puppet) for it to reload the configuration and the plugin.
+  * [Restart the `pe-puppetserver`](https://puppet.com/docs/puppetserver/latest/restarting.html) process (`puppet-server` for Open Source Puppet) for it to reload the configuration and the plugin.
 
   * Run `puppet agent -t` on an agent; if you are using the suggested name, use `source="http:puppet-report-summary"` in your Splunk search field to show the reports as they arrive.
 
@@ -195,7 +195,7 @@ You can manually update the `splunk_hec.yaml` file with these settings:
 "ssl_ca" : "splunk_ca.cert"
 ```
 
-Alternatively, you can create a [profile class](https://puppet.com/docs/pe/2019.8/osp/the_roles_and_profiles_method.html) that copies the `splunk_ca.cert` as part of invoking the splunk_hec class:
+Alternatively, you can create a [profile class](https://puppet.com/docs/pe/latest/osp/the_roles_and_profiles_method.html) that copies the `splunk_ca.cert` as part of invoking the splunk_hec class:
 
 ```
 class profile::splunk_hec {
@@ -225,8 +225,9 @@ The following parameters are utilized to configure which facts (including custom
   * `facts_blocklist` (**Optional**)
 
 To configure which facts to collect add the `collect_facts` parameter to the `splunk_hec` class and modify the array of facts presented.
-    * To collect **all facts** available at the time of the Puppet run, add the special value `all.facts` to the `collect_facts` array.
-    * When collecting **all facts**, you can configure the optional parameter `facts_blocklist` with an array of facts that should not be collected.
+
+  * To collect **all facts** available at the time of the Puppet run, add the special value `all.facts` to the `collect_facts` array.
+  * When collecting **all facts**, you can configure the optional parameter `facts_blocklist` with an array of facts that should not be collected.
 
 ## PE Event Forwarding
 
@@ -276,7 +277,7 @@ This feature can be configured to send these events from non server nodes if nee
 
 ### Supported Puppet Versions For Event Forwarding
 
-The puppetlabs-pe_event_forwarding module that this feature depends on is compatible with PE versions in the 2019 range starting at 2019.8.7 and above, and then 2021 versions from 2021.2 and above.
+The puppetlabs-pe_event_forwarding module that this feature depends on is compatible with PE versions in the 2019 range starting at **2019.8.7** and above, and then 2021 versions from **2021.2** and above.
 
 Versions in the PE 2019 series below 2019.8.7 and in the 2021 series in versions below 2021.2 did not recieve an update to some of the API methods in PE that are required for the puppetlabs-pe_event_forwarding module to function properly.
 
@@ -427,7 +428,7 @@ This module has some limitations in a FIPS environment.
 
 1. SSL configuration steps and parameters are different under FIPS
 
-    - The CA certificate PEM file must be appended to the end of the `localcacert` file. Find the path to the file by running [`puppet config print localcacert`](https://puppet.com/docs/puppet/7/configuration.html#localcacert). Keep in mind that this file will be overwritten any time the puppetserver is upgraded to a new version and this step will have to be done again. Consider copying a backup of this file to a safe location before attempting to add content to it until correct funtioning of the Puppet Server and this module can be validated.
+    - The CA certificate PEM file must be appended to the end of the `localcacert` file. Find the path to the file by running [`puppet config print localcacert`](https://puppet.com/docs/puppet/latest/configuration.html#localcacert). Keep in mind that this file will be overwritten any time the puppetserver is upgraded to a new version and this step will have to be done again. Consider copying a backup of this file to a safe location before attempting to add content to it until correct funtioning of the Puppet Server and this module can be validated.
 
       ```
       ca_file=`puppet config print localcacert`
@@ -441,11 +442,11 @@ This module has some limitations in a FIPS environment.
 
 ## Advanced Topics
 
-* [Advanced Puppet Configuration](https://github.com/puppetlabs/puppetlabs-splunk_hec/blob/v0.8.1/docs/advanced_puppet_configuration.md)
-* [Advanced Splunk Configuration](https://github.com/puppetlabs/puppetlabs-splunk_hec/blob/v0.8.1/docs/advanced_splunk_configuration.md)
-* [Fact Terminus Support](https://github.com/puppetlabs/puppetlabs-splunk_hec/blob/v0.8.1/docs/fact_terminus_support.md)
-* [Puppet Metrics Collection](https://github.com/puppetlabs/puppetlabs-splunk_hec/blob/v0.8.1/docs/puppet_metrics_collector_support.md)
-* [Troublshooting and Verification](https://github.com/puppetlabs/puppetlabs-splunk_hec/blob/v0.8.1/docs/troubleshooting_and_verification.md)
+* [Advanced Puppet Configuration](https://github.com/puppetlabs/puppetlabs-splunk_hec/blob/main/docs/advanced_puppet_configuration.md)
+* [Advanced Splunk Configuration](https://github.com/puppetlabs/puppetlabs-splunk_hec/blob/main/docs/advanced_splunk_configuration.md)
+* [Fact Terminus Support](https://github.com/puppetlabs/puppetlabs-splunk_hec/blob/main/docs/fact_terminus_support.md)
+* [Puppet Metrics Collection](https://github.com/puppetlabs/puppetlabs-splunk_hec/blob/main/docs/puppet_metrics_collector_support.md)
+* [Troubleshooting and Verification](https://github.com/puppetlabs/puppetlabs-splunk_hec/blob/main/docs/troubleshooting_and_verification.md)
 
 ## Known Issues
 
@@ -456,7 +457,7 @@ This module has some limitations in a FIPS environment.
 ## Breaking Changes
 
   * `>= 0.5.0` The `splunk_hec::url` parameter now expects a full URI of **https://servername:8088/services/collector**.
-  * `0.5.0` -> `0.6.0` Switches to the fact terminus cache setting via `splunk_routes.yaml` to ensure compatibility with [CD4PE](https://puppet.com/docs/continuous-delivery/4.x/cd_user_guide.html). See [Fact Terminus Support](https://github.com/puppetlabs/puppetlabs-splunk_hec/blob/v0.8.1/docs/fact_terminus_support.md) for guides on how to change it. Prior to deploying this module, remove the setting `facts_terminus` from the `puppet_enterprise::profile::master` class in the `PE Master` node group in your environment if you set it in previous versions of this module (`0.6.0 <`). It will prevent PE from operating normally if left on.
+  * `0.5.0` -> `0.6.0` Switches to the fact terminus cache setting via `splunk_hec_routes.yaml` to ensure compatibility with [CD4PE](https://puppet.com/docs/continuous-delivery/4.x/cd_user_guide.html). See [Fact Terminus Support](https://github.com/puppetlabs/puppetlabs-splunk_hec/blob/main/docs/fact_terminus_support.md) for guides on how to change it. Prior to deploying this module, remove the setting `facts_terminus` from the `puppet_enterprise::profile::master` class in the `PE Master` node group in your environment if you set it in previous versions of this module (`0.6.0 <`). It will prevent PE from operating normally if left on.
 
 ## Release Process
 

--- a/docs/advanced_puppet_configuration.md
+++ b/docs/advanced_puppet_configuration.md
@@ -1,14 +1,18 @@
 ## Advanced Puppet Configuration
------------
 
-The splunk_hec module also supports customizing the `facts_terminus` and `facts_cache_terminus` names in the custom routes.yaml it deploys. If you are using a different facts_terminus (ie, not PuppetDB), you will want to set that parameter.
+The `splunk_hec` module also supports customizing the `facts_terminus` and `facts_cache_terminus` names in the custom `splunk_hec_routes.yaml` it deploys. If you are using a different `facts_terminus` (i.e. not PuppetDB), you will want to configure that parameter.
 
-If you are already using a custom routes.yaml, these are the equivalent instructions of what the splunk_hec module does, the most important setting is configuring `cache: splunk_hec`
-- Create a custom splunk_routes.yaml file to override where facts are cached 
-```yaml
-master:
-  facts:
-    terminus: puppetdb
-    cache: splunk_hec
-```
-- Set this routes file instead of the default one with `puppet config set route_file /etc/puppetlabs/puppet/splunk_routes.yaml --section master`
+If you are already using a custom `routes.yaml`, these are the equivalent instructions of what the `splunk_hec` module does, the most important setting is configuring `cache: splunk_hec`.
+
+  * Create a custom `splunk_hec_routes.yaml` file to override where facts are cached:
+
+  ```
+    ---
+    master:
+      facts:
+        terminus: puppetdb
+        cache: splunk_hec
+  ```
+
+  * Set this routes file instead of the default one with the following command:
+    * `puppet config set route_file /etc/puppetlabs/puppet/splunk_hec_routes.yaml --section master`

--- a/docs/advanced_splunk_configuration.md
+++ b/docs/advanced_splunk_configuration.md
@@ -1,9 +1,11 @@
 ## Advanced Splunk Configuration Options
------------
-The splunk_hec class and data processors support setting individual HEC tokens and URLs for each type of data supported. This is designed so users can specify a different HEC token if they wish their Puppet Reports are stored in a different index than their Facts, etc. Making changes here assumes you know how to use indexs and update the advanced search macros in Splunk so the Report Viewer can load data from those indexes.
 
-- Summary Reports: Corresponds to puppet:summary in the Puppet Report Viewer, use `token_summary` and `url_summary` parameter or value in splunk_hec.yaml
-- Fact Data: Corresponds to puppet:facts in the Puppet Report Viewer, use `token_facts` and `url_facts` parameter or value in splunk_hec.yaml
-- PE Metrics: Corresponds to puppet:metrics in the Puppet Report Viewer, use `token_metrics` and `url_metrics` parameter or value in splunk_hec.yaml (at this time, collecting PE Metrics is not supported, but the sourcetype exists in the app)
+The `splunk_hec` class and data processors support setting individual HEC tokens and URLs for the following data types:
 
-Different URLs only need to be specified if different HEC systems entirely are being used. If one is using one collecter server, but multiple HECs, just provide the `url` setting as before, and specify each sourcetype's corresponding HEC token.
+  * **Summary Reports**: Corresponds to the `puppet:summary` source type in the Puppet Report Viewer. Use the `token_summary` and `url_summary` parameters to configure them in the `splunk_hec.yaml` file.
+  * **Fact Data**: Corresponds to the `puppet:facts` source type in the Puppet Report Viewer. Use the `token_facts` and `url_facts` parameters to configure them in the `splunk_hec.yaml` file.
+  * **PE Metrics**: Corresponds to the `puppet:metrics` source type in the Puppet Report Viewer. Use the `token_metrics` and `url_metrics` parameters to configure them in the `splunk_hec.yaml` file.
+
+Different URLs only need to be specified if different HEC systems entirely are being used. If one is using one collecter server, but multiple HECs, just use the single `url` parameter as before, and specify each source type's corresponding HEC token.
+
+**Note**: Making these changes here assumes that you know how to properly use indexes and update the advanced search macros in Splunk to ensure that the Report Viewer can load data from those indexes.

--- a/docs/custom_installation.md
+++ b/docs/custom_installation.md
@@ -1,57 +1,61 @@
 ## Custom Installation
---------------------
 
-__If you are installing this module using a control-repo, you must have splunk_hec in your production environment's Puppetfile so the puppetserver process can load the libraries it needs properly. You can then create a feature branch to enable them and test the configuration, but the libraries must be in production otherwise the feature branch won't work as expected. If your puppetserver is in a different environment, please add this module to the Puppetfile in that environment as well.__
+> **Please Note**: If you are installing this module using a [`control-repo`](https://puppet.com/docs/pe/latest/control_repo.html) you must have `splunk_hec` in your production environment's [`Puppetfile`](https://puppet.com/docs/pe/latest/puppetfile.html) so the Puppet Server process can properly load the required libraries. You can then create a feature branch to enable them and test the configuration, but the libraries **must be** in `production`; otherwise the feature branch won't work as expected. If your Puppet Server is in a different environment, please add this module to the `Puppetfile` in that environment as well.
 
-The steps below will help install and troubleshoot the report processor on a single Puppet Master, including manual steps to configure a puppet-server, and to use the included splunk_hec class. Because one is modifying production machines, these steps allow you to validate your settings before deploying the changes live. See the tl,dr; instructions for
+The steps below will help install and troubleshoot the report processor on a standard Puppet Primary Server; including manual steps to configure compilers (Puppet Servers), and to use the included `splunk_hec` class. Because one is modifying production machines, these steps allow you to validate your settings before deploying the changes live.
 
-1. Install the Puppet Report Viewer Addon in Splunk. This will import the needed sourcetypes to configure Splunk's HTTP Endpoint Collector (HEC) and provide a dashboard that will show the reports once they are sent to Splunk.
+1. Install the Puppet Report Viewer app in Splunk. This will import the needed source types to configure Splunk's HTTP Endpoint Collector (HEC) and provide a dashboard that will show the reports once they are sent to Splunk.
 
-2. Create a Splunk HEC Token or use an existing one that sends to main index and does not have acknowledgement enabled. Follow the steps provided by Splunk's [Getting Data In Guide](http://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector) if you are new to HTTP Endpoint Collectors.
+2. Create a Splunk HEC Token or use an existing one that sends to `main` index and **does not** have acknowledgement enabled. Follow the steps provided by Splunk's [Getting Data In Guide](http://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector) if you are new to HTTP Endpoint Collectors.
 
-3. Install this Puppet module in the environment that manages your Puppet Servers are using (probably `production`)
+3. [Install this Puppet module](https://puppet.com/docs/puppet/latest/modules_installing.html) in the environment that your Puppet Servers are using (e.g. `production`).
 
-4. Run `puppet plugin download` on your Puppet Server to sync the content. Some users with strict permissions may need to run `umask 022` first
+4. Run `puppet plugin download` on your Puppet Servers to sync the content. Some users with strict permissions may need to run `umask 022` first.
 
-5. Create a `/etc/puppetlabs/puppet/splunk_hec.yaml` (see examples directory for one) adding your Splunk Server URL to the collector (usually something like `https://splunk-dev:8088/services/collector`) & Token from step 1
-  - You can add 'timeout' as an optional parameter, default value is 1 second for both open and read sessions, so take value x2 for real world use
-  - Provide a `pe_console` value that is the hostname for the Puppet Enterprise Console, which Splunk can use to lookup further information if the installation is a multimaster setup (it is best practice to set this if you're anticipating scaling out more masters in the future).
+  * **Please Note**: If permissions are too restrictive you may see the following error in the Puppet Server logs:
 
-  ```
----
-"url" : "https://splunk-dev.testing.local:8088/services/collector"
-"token" : "13311780-EC29-4DD0-A796-9F0CDC56F2AD"
-```
-(Note: If HA is enabled you will need to ensure these settings exist in each master. This is often done through the PE HA Replica node group.)
+      ```
+      Could not find terminus splunk_hec for indirection facts
+      ```
 
-6. Run `puppet apply -e 'notify { "hello world": }' --reports=splunk_hec` from the Puppet Server, this will load the report processor and test your configuration settings without actually modifying your Puppet Server's running configuration. If you are using the Puppet Report Viewer app in Splunk then you will see the page update with new data. If not, perform a search by the sourcetype you provided with your HEC configuration.
+5. Create `/etc/puppetlabs/puppet/splunk_hec.yaml` (see the [examples directory](https://github.com/puppetlabs/puppetlabs-splunk_hec/main/examples/splunk_hec.yaml)), adding your Splunk Server URL to the `url` parameter (e.g. `https://splunk-dev:8088/services/collector`) and HEC Token created during step 2 to the `splunk_token` parameter.
+  * You can add `timeout` as an optional parameter. The **default value** is `1` second for both open and read sessions, so take value x2 for real world use.
+  * **PE Only**: Provide the `pe_console` parameter value. This is the FQDN for the PE console, which Splunk can use to lookup further information if the installation utilizes compilers (it is best practice to set this if you're anticipating scaling the installation in the future).
 
-7. If configured properly the Puppet Report Viewer app in Splunk will show 1 node in the Overview tab.
+      ```
+      ---
+      "url" : "https://splunk-dev.testing.local:8088/services/collector"
+      "token" : "13311780-EC29-4DD0-A796-9F0CDC56F2AD"
+      ```
+      (**Note**: If [Disaster Recovery](https://puppet.com/docs/pe/latest/dr_overview.html) is enabled you will need to ensure these settings exist on the Replica node as well. This is often done through the `PE HA Replica` node group.)
 
-8. Now it is time to roll these settings out to the fleet of to the Puppet Masters in the installation. For Puppet Enterprise users:
-	- Navigate to Classification -> PE Infrastructure -> PE Master
-	- Select Configuration
-	- Press Refresh to ensure the splunk_hec class is loaded
-	- Add new class `splunk_hec`
-	- From the `Parameter name` select at least `url` and `token` and provide the same attributes from the testing configuration file
-	- Optionally set `enable_reports` to `true` if there isn't another component managing the servers reports setting, otherwise manually add `splunk_hec` to the settings as described in the manual steps. Note that if `enable_reports` is set to `true`, then you can have the module automatically add the `splunk_hec` report processor to the servers reports setting by setting the `reports` parameter to the empty string, `''`.
-	- Commit changes and run Puppet. It is best to navigate to the PE Certificate Authority Classification gorup and run Puppet there first, before running Puppet on the remaining machines
+6. Run `puppet apply -e 'notify { "hello world": }' --reports=splunk_hec` from the Puppet Server, this will load the report processor and test your configuration settings without actually modifying your Puppet Server's running configuration. If you are using the Puppet Report Viewer app in Splunk then you will see the page update with new data. If not, perform a search by the `sourcetype` you provided with your HEC configuration.
 
-9. For Inventory support in the Puppet Report Viewer, see the [Fact Terminus Support](fact_terminus_support.md)
+7. If configured properly the Puppet Report Viewer app in Splunk will show 1 node in the `Overview` tab.
 
-### Manual steps:
+8. Now it is time to roll these settings out to the fleet of Puppet Servers in the installation. For PE users:
+  * In the [PE console](https://puppet.com/docs/pe/latest/console_accessing.html), navigate to `Node groups` and expand `PE Infrastructure`.
+  * Select `PE Master` and navigate to the `Classes` tab.
+  * Click **Refresh** to ensure that the `splunk_hec` class is loaded.
+  * Add new class `splunk_hec`.
+  * From the `Parameter` drop down list you will need to configure at least `url` and `token`, providing the same values from the testing configuration file.
+      * Optionally set `enable_reports` to `true` if there isn't another component managing the servers reports setting. Otherwise manually add `splunk_hec` to the settings as described in the [manual steps](#manual-steps) below.
+  * Commit changes and run Puppet. It is best to navigate to the `PE Certificate Authority` node group and run Puppet there first, before running Puppet on the remaining nodes.
 
-- Add `splunk_hec` to `/etc/puppetlabs/puppet/puppet.conf` reports line under the master's configuration block
+9. For Inventory support in the Puppet Report Viewer, see [Fact Terminus Support](https://github.com/puppetlabs/puppetlabs-splunk_hec/blob/main/docs/fact_terminus_support.md).
 
-```
-[master]
-node_terminus = classifier
-storeconfigs = true
-storeconfigs_backend = puppetdb
-reports = puppetdb,splunk_hec
-```
+#### Manual Steps:
 
-- Restart the pe-puppetserver process (puppet-server for Open Source Puppet) for it to reload the configuration and the plugin
+  * Add `splunk_hec` to `reports` under the `[master]` configuration block in `/etc/puppetlabs/puppet/puppet.conf`:
 
-- Run `puppet agent -t` on an agent, if you are using the suggested name, use `source="http:puppet-report-summary"` in your Splunk search field to show the reports as they arrive
+    ```
+    [master]
+    node_terminus = classifier
+    storeconfigs = true
+    storeconfigs_backend = puppetdb
+    reports = puppetdb,splunk_hec
+    ```
 
+  * [Restart the `pe-puppetserver`](https://puppet.com/docs/puppetserver/latest/restarting.html) process (`puppet-server` for Open Source Puppet) for it to reload the configuration and the plugin.
+
+  * Run `puppet agent -t` on an agent; if you are using the suggested name, use `source="http:puppet-report-summary"` in your Splunk search field to show the reports as they arrive.

--- a/docs/customized_reporting.md
+++ b/docs/customized_reporting.md
@@ -1,25 +1,93 @@
 ## Customized Reporting
-----------
-As of 0.8.0 and later the report processor can be configured to include Logs and Resource Events along with the existing summary data. Because this data varies between runs and agents in Puppet, it is difficult to predict how much data one will use in Splunk as a result. However this removes the need for configuring the Detailed Report Generation alerts in Splunk to retrieve that information, which is useful for large installations that need to retrieve a large amount of data. You can now just send the information from Puppet directly.
 
-Add one or more of these parameters based on the desired outcome, these apply to the state of the puppet runs, one cannot filter by facts on which nodes these are in effect for. So one can get `logs when a puppet run fails`, but not `logs when a windows server puppet run fails`. By default none of these are enabled.
+As of `0.8.0` and later the report processor can be configured to include [**Logs**](https://puppet.com/docs/puppet/latest/format_report.html#puppet::util::log) and [**Resource Events**](https://puppet.com/docs/puppet/latest/format_report.html#puppet::resource::status) along with the existing summary data. Because this data varies between runs and agents in Puppet, it is difficult to predict how much data you will use in Splunk as a result. However, this removes the need for configuring the **Detailed Report Generation** alerts in Splunk to retrieve that information; which may be useful for large installations that need to retrieve a large amount of data. You can now just send the information from Puppet directly.
+
+Add one or more of these parameters based on the desired outcome, these apply to the state of the puppet runs. You cannot filter by facts on which nodes these are in effect for. As such, you can get ***logs when a puppet run fails***, but not *logs when a `windows` server puppet run fails*.
+
+By default this type of reporting is not enabled.
+
+**Parameters**:
+
+##### event_types (Requires `puppetlabs-pe_event_forwarding` module)
+
+`Array`: Determines which event types should be forwarded to Splunk. Default value includes all event types. This can be one, or any of the following:
+
+  * `classifier`
+  * `code-manager`
+  * `orchestrator`
+  * `pe-console`
+  * `rbac`
 
 ##### include_logs_status
 
-Array: Determines if [logs](https://puppet.com/docs/puppet/latest/format_report.html#puppet::util::log) should be included based on the return status of the puppet agent run. The can be none, one, or any of the following: `failed changed unchanged`
+`Array`: Determines if [logs](https://puppet.com/docs/puppet/latest/format_report.html#puppet::util::log) should be included based on the return status of the puppet agent run. This can be none, one, or any of the following:
+
+  * `failed`
+  * `changed`
+  * `unchanged`
 
 ##### include_logs_catalog_failure
 
-Boolean: Include logs if a catalog fails to compile. This is a more specific type of failure that indicates a serverside issue. Values: `true false`
+`Boolean`: Include logs if a [catalog](https://puppet.com/docs/puppet/latest/subsystem_catalog_compilation.html) fails to compile. This is a more specific type of failure that indicates a server-side issue.
+
+  * `true`
+  * `false`
 
 ##### include_logs_corrective_change
 
-Boolean: Include logs if a there is a corrective change (a PE only feature) - indicating drift was detected from the last time puppet ran on the system. Values: `true false`
+`Boolean`: Include logs if a there is a [corrective change](https://puppet.com/docs/pe/latest/analyze_changes_across_runs.html) (a PE only feature) - indicating drift was detected from the last time puppet ran on the system.
+
+  * `true`
+  * `false`
 
 ##### include_resources_status
 
-Array: Determines if [resource events](https://puppet.com/docs/puppet/latest/format_report.html#puppet::resource::status) should be included based on the return status of the puppet agent run. Note: this only includes resources whose status is not `unchanged` - not the entire catalog. The can be none, one, or any of the following: `failed changed unchanged`
+`Array`: Determines if [resource events](https://puppet.com/docs/puppet/latest/format_report.html#puppet::resource::status) should be included based on the return status of the puppet agent run. **Note**: This only includes resources whose status is not `unchanged` - not the entire catalog. The can be none, one, or any of the following:
+
+  * `failed`
+  * `changed`
+  * `unchanged`
 
 ##### include_resources_corrective_change
 
-Boolean: Include resource events if a there is a corrective change (a PE only feature) - indicating drift was detected from the last time puppet ran on the system. Values: `true false`
+`Boolean`: Include resource events if a there is a corrective change (a **PE only** feature) - indicating drift was detected from the last time puppet ran on the system.
+
+  * `true`
+  * `false`
+
+##### summary_resources_format
+
+`String`: If `include_resources_corrective_change` or `include_resources_status` is set and therefore `resource_events` are being sent as part of `puppet:summary` events, we can choose what format they should be sent in. Depending on your usage within Splunk, different formats may be preferable. The possible values are:
+
+  * `hash` :: **Default Value**
+  * `array`
+
+Here is an example of the data that will be forwarded to Splunk in each instance:
+
+**`hash`**:
+
+```json
+{
+  "resource_events": {
+    "File[/etc/something.conf]": {
+      "resource": "File[/etc/something.conf]",
+      "failed": false,
+      "out_of_sync": true
+    }
+  }
+}
+```
+
+**`array`**:
+
+```json
+{
+  "resource_events": [
+    {
+      "resource": "File[/etc/something.conf]",
+      "failed": false,
+      "out_of_sync": true
+    }
+  ]
+}
+```

--- a/docs/fact_terminus_support.md
+++ b/docs/fact_terminus_support.md
@@ -1,12 +1,18 @@
 ## Fact Terminus Support
------------
 
-The `splunk_hec` module provides a fact terminus that will send a configurable set of facts to the same HEC that the report processor is using, however as a `puppet:facts` sourcetype. This populates the Details and Inventory tabs in the Puppet Report Viewer. 
+The `splunk_hec` module provides a fact terminus that will send a configurable set of facts to the same HEC that the report processor is using, with the `puppet:facts` source type.
 
-- Set the parameter `splunk_hec::manage_routes` to `true`. In the PE console, this would be by adding `manage_routes` in the `Classification -> PE Infrastructure -> Master -> Configuration` view under the `splunk_hec`
-- Run Puppet on the machines in that node group
-- PE PuppetServer will restart once the new routes.yaml is deployed and configured.
-- To configure which facts to collect (such as custom facts) add the `collect_facts` parameter in the `splunk_hec` class and modify the array of facts presented. The following facts are collected regardless to ensure the functionality of the Puppet Report Viever:
+  * Set the parameter `splunk_hec::manage_routes` to `true`.
+    * In the PE console, this would be done by adding the `manage_routes` parameter in the node group configured with the `splunk_hec` class.
+  * Run Puppet on the machines in that node group.
+  * The `pe-puppetserver` service will restart once the new routes.yaml is deployed and configured.
+
+To configure which facts to collect add the `collect_facts` parameter to the `splunk_hec` class and modify the array of facts presented.
+
+  * To collect **all facts** available at the time of the Puppet run, add the special value `all.facts` to the `collect_facts` array.
+  * When collecting **all facts**, you can configure the optional parameter `facts_blocklist` with an array of facts that should not be collected.
+
+**Note**: The following facts are collected regardless as this data is utilized in a number of the dashboards in the Puppet Report Viewer:
 
 ```
 'os'

--- a/docs/puppet_metrics_collector_support.md
+++ b/docs/puppet_metrics_collector_support.md
@@ -1,4 +1,20 @@
 ## Puppet Metrics Collector Support
------------
 
-This module can forward metrics collected by the [Puppet Metrics Collector](https://forge.puppet.com/puppetlabs/puppet_metrics_collector) module. To enable this, once reporting is working with this module and the Metrics Collector module is installed, set the `metrics_server_type` parameter in the puppet_metrics_collector to Splunk. For more information refer to the modules [documentation](https://forge.puppet.com/puppetlabs/puppet_metrics_collector#metrics-server-parameters). Version 6.0.0 or greater is required to send metric data to splunk.
+This module can be utilized in conjunction with the [Puppet Metrics Collector](https://forge.puppet.com/puppetlabs/puppet_metrics_collector) module to populate the dashboards in the Metrics tab of the Puppet Report Viewer app.
+
+To enable this, once reporting is working with this module and the Metrics Collector module installed, set the `puppet_metrics_collector::metrics_server_type` parameter to `splunk_hec`.
+
+---
+
+> In PE **2019.8.7+**, with `splunk_hec` and the Puppet Report Viewer properly configured, you will want to configure the following parameters within the `puppet_enterprise` class in the **PE Infrastructure** node group:
+
+>  * `puppet_enterprise::enable_metrics_collection: true`
+>  * `puppet_enterprise::enable_system_metrics_collection: true`
+
+>In your hiera data you will then want to configure the `metrics_server_type` parameter:
+
+>  * `puppet_metrics_collector::metrics_server_type: ‘splunk_hec’`
+
+---
+
+For more information please refer to the metrics collectors [documentation](https://forge.puppet.com/modules/puppetlabs/puppet_metrics_collector#metrics_server_type).

--- a/docs/ssl_support.md
+++ b/docs/ssl_support.md
@@ -1,15 +1,14 @@
-## SSL Support
------------
+## SSL Configuration
 
 Configuring SSL support for this report processor and tasks requires that the Splunk HEC service being used has a [properly configured SSL certificate](https://docs.splunk.com/Documentation/Splunk/latest/Security/AboutsecuringyourSplunkconfigurationwithSSL). Once the HEC service has a valid SSL certificate, the CA will need to be made available to the report processor to load. The supported path is to install a copy of the Splunk CA to a directory called `/etc/puppetlabs/puppet/splunk_hec/` and provide the file name to `splunk_hec` class.
 
-One can update the splunk_hec.yaml file with these settings:
+You can manually update the `splunk_hec.yaml` file with these settings:
 
 ```
 "ssl_ca" : "splunk_ca.cert"
 ```
 
-Or create a profile that copies the `splunk_ca.cert` as part of invoking the splunk_hec class:
+Alternatively, you can create a [profile class](https://puppet.com/docs/pe/latest/osp/the_roles_and_profiles_method.html) that copies the `splunk_ca.cert` as part of invoking the splunk_hec class:
 
 ```
 class profile::splunk_hec {
@@ -28,3 +27,5 @@ class profile::splunk_hec {
   }
 }
 ```
+
+The certificate provided to the `ssl_ca` parameter is a supplement to the system ca certificates store. By default, the Ruby classes that perform certificate validation will attempt to use the system certificates first, and then if the certificate cannot be validated there, it will load the ca file in `ssl_ca`. Occasionally, the system cert store will cause validation errors prior to checking the file at `ssl_ca`. To avoid this you can set `ignore_system_cert_store` to `true`. This will allow the code to use ONLY the file at `ssl_ca` to perform certificate validation.

--- a/docs/troubleshooting_and_verification.md
+++ b/docs/troubleshooting_and_verification.md
@@ -1,40 +1,59 @@
-## Troubleshooting and verification
------------
-Report processors and fact termini (what this module adds) run inside the Puppet Server process so that is where to look for logs. In a healthy system running 0.5.0 or later of this module, one will see something like this:
+## Troubleshooting and Verification
+
+### Puppet
+
+Custom report processors and fact terminus indirectors run inside the Puppet Server process. For both Puppet Enterprise (PE) and Open Source Puppet (OSP) the Puppet Server logs are located at `/var/log/puppetlabs/puppetserver/puppetserver.log`.
+
+With versions `0.5.0+` of the `splunk_hec` module configured, a healthy system would log entries like the ones below:
+
 ```
-[cbarker@puppet ~]$ sudo tail -n 60 /var/log/puppetlabs/puppetserver/puppetserver.log | grep Splunk
+# grep -i splunk /var/log/puppetlabs/puppetserver/puppetserver.log
 2019-06-17T12:44:47.729Z INFO  [qtp1685349172-4356] [puppetserver] Puppet Submitting facts to Splunk at https://splunk-dev.c.splunk-217321.internal:8088/services/collector
 2019-06-17T12:44:48.322Z INFO  [qtp1685349172-15004] [puppetserver] Puppet Submitting report to Splunk at https://splunk-dev.c.splunk-217321.internal:8088/services/collector
 2019-06-17T12:45:25.913Z INFO  [qtp1685349172-28874] [puppetserver] Puppet Submitting facts to Splunk at https://splunk-dev.c.splunk-217321.internal:8088/services/collector
 ```
 
-For older versions (splunk_hec older than 0.5.0) or if the fact terminus is not configured one would see:
+Versions prior to `0.5.0`, or `0.5.0+` without the fact terminus configured, a healthy system would log entries like the ones below:
+
 ```
-[cbarker@puppet ~]$ sudo tail -n 60 /var/log/puppetlabs/puppetserver/puppetserver.log | grep Splunk
+# grep -i splunk /var/log/puppetlabs/puppetserver/puppetserver.log
 2019-06-17T12:48:21.646Z INFO  [qtp1685349172-4354] [puppetserver] Puppet Submitting report to Splunk at https://splunk-dev.c.splunk-217321.internal:8088/services/collector
 2019-06-17T12:48:31.689Z INFO  [qtp1685349172-4354] [puppetserver] Puppet Submitting report to Splunk at https://splunk-dev.c.splunk-217321.internal:8088/services/collector
 2019-06-17T12:49:22.881Z INFO  [qtp1685349172-4356] [puppetserver] Puppet Submitting report to Splunk at https://splunk-dev.c.splunk-217321.internal:8088/services/collector
 ```
 
-If neither appear in the logs, then the puppetserver has yet to be configured, check the reports and routes settings for report processor and fact submission support respectively, this has to be checked on all puppet servers, including the Master of Masters, to ensure every puppet run is logged:
-Reports enabled properly using the module:
+If neither of those entries appears in the log, then the Puppet Server has yet to be configured. Check the `reports` and `route_file` settings in the `puppet.conf` to ensure report processing and fact indirection for `splunk_hec` is properly configured on all of the infrastructure nodes in the installation (e.g. Primary Server, Replica, Compilers). This can be confirmed with the following command.
+
 ```
-[cbarker@puppet ~]$ sudo /opt/puppetlabs/bin/puppet config print reports --section master
-puppetdb,splunk_hec
-```
-Facts enabled properly using the module:
-```
-[cbarker@puppet ~]$ sudo /opt/puppetlabs/bin/puppet config print route_file --section master
-/etc/puppetlabs/puppet/splunk_hec_routes.yaml
+# puppet config print reports route_file --section master
+reports = puppetdb,splunk_hec
+route_file = /etc/puppetlabs/puppet/splunk_hec_routes.yaml
 ```
 
-To verify the reports are in Splunk properly, search all indexes for the source type 'puppet:summary' for reports, 'puppet:facts' for facts:
-`index=* sourcetype=puppet:summary` and `index=* sourcetype=puppet:facts`
+---
 
-The number of events corresponds to the number of Puppet runs that have occured during that time period, not number of hosts. To verify all hosts in an environment have submitted facts/reports, one will need to dedup the events by host to get an accurate count, this is only worth doing after the module has been deployed for at least an hour (or longer, depending on the Puppet run interval set in the environment). In the Splunk search view, set the time window to the last 60 minutes and use the following search, the resulting Event Count will match the number of nodes in the Puppet Enterprise console:
-`index=* sourcetype=puppet:summary | dedup host`
+### Splunk
 
-If you are using multiple PE consoles (ie, multiple Puppet Enterprise installations), you will need to add an additional filter by pe_console value:
-`index=* sourcetype=puppet:summary | pe_console=puppet.company.com | dedup host`
+To verify that reports and facts from Puppet are properly ingested by Splunk, search all indexes for the source type `puppet:*`.
 
-For troubleshooting detailed reports and display issues in the Splunk Console, please see the documentation for the [Puppet Report Viewer](https://github.com/puppetlabs/ta-puppet-report-viewer) if the above steps have demonstrated that the Reports and Facts are being sent to Splunk and stored appropriately in the right sourcetypes.
+```
+index=* sourcetype=puppet:*
+```
+
+The number of events corresponds to the number of Puppet runs, doubled (1 event for the report and 1 event for the facts collected), that have occured during that time period; not the number of hosts. To verify all hosts in an environment have submitted reports and facts, you would need to `dedup` the events by `host` to get an accurate count.
+
+Once Puppet has been sending data to Splunk for ~60 minutes, set the time range picker to the last 60 minutes and use the following search:
+
+```
+index=* sourcetype=puppet:summary | dedup host
+```
+
+The resulting event count should match the number of nodes listed in the Puppet Enterprise console. If you are utilizing multiple Puppet installations you will need to filter by the `pe_console` value:
+
+```
+index=* sourcetype=puppet:summary | pe_console=puppet.company.com | dedup host
+```
+
+In the event the above steps have confirmed that the reports/facts are being sent to Splunk and stored appropriately by the correct source types; and you are experiencing issues with detailed reports or display issues in the Splunk Console, please see the documentation for the [Puppet Report Viewer](https://github.com/puppetlabs/ta-puppet-report-viewer).
+
+---


### PR DESCRIPTION
# Summary

Fixed a number of typos and syntax issues in the docs and README.

# Detailed Description

Over time sections of the docs have made it to the main README, then those new sections in the README are eventually updated. But the changes never make it back to the docs dir we link, so I've made changes to correct that. Additionally, I updated a number of links in the README so they will redirect to the latest version of Puppet docs.

# Checklist

[X] Ensure README is updated
  [X] Any changes to existing documentation
  [X] Link to external Puppet documentation
  [X] Review [Support Playbook](https://confluence.puppetlabs.com/display/SUP/Splunk+HEC+Module+Support+Playbook) for any needed updates
[X] PR title is "(Ticket|Maint) Short Description"
[X] Commit title matches PR title
