### PR TITLE
(MAINT) Conditional event type filtering setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file. The format 
 
 - Ability to collect all facts against a blocklist. [#170](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/170)
 
+### Fixed
+
+- Prevent the `event_types` parameter from being configured unless `events_reporting_enabled` is set to **true**. [#174](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/174)
+
 ## [v1.1.0](https://github.com/puppetlabs/puppetlabs-splunk_hec/tree/v1.1.0) (2021-11-09)
 
 [Full Changelog](https://github.com/puppetlabs/puppetlabs-splunk_hec/compare/v1.0.1..v1.1.0)

--- a/templates/splunk_hec.yaml.epp
+++ b/templates/splunk_hec.yaml.epp
@@ -74,8 +74,8 @@
 <% } -%>
 <% if $splunk_hec::events_reporting_enabled { -%>
 "events_reporting_enabled" : "<%= $splunk_hec::events_reporting_enabled %>"
-<% } -%>
 "event_types" : "<%= $splunk_hec::event_types %>"
+<% } -%>
 <% if $splunk_hec::orchestrator_data_filter { -%>
 "orchestrator_data_filter" :
 <% $splunk_hec::orchestrator_data_filter.each |$subset| {-%>


### PR DESCRIPTION
# Summary

Prevent `splunk_hec::event_type_filtering` from being added to `splunk_hec.yaml` unless event reporting is enabled.

# Detailed Description

Moved the `splunk_hec::event_type_filtering` parameter into the conditional for `splunk_hec::events_reporting_enabled` as the former is not required unless the latter is configured.

# Checklist

[X] Unit Tests
[X] Acceptance Tests
[X] PR title is "(Ticket|Maint) Short Description"
[X] Commit title matches PR title
