### PR TITLE
(PIE-959) Fix splunk_hec_agent_only_node fact

### DIFF
--- a/lib/facter/splunk_hec_agent_only_node.rb
+++ b/lib/facter/splunk_hec_agent_only_node.rb
@@ -1,10 +1,11 @@
-# This code is in a fact because attempting to get these values and
-# compare them using any other method, like just using the $settings variable
-# makes unit testing with rspec-puppet extremely difficult. Putting this code
-# here makes it easy to choose the value to assign for this fast and therefore
-# easier to code different code paths through the init.pp file.
+# frozen_string_literal: true
+
 Facter.add(:splunk_hec_agent_only_node) do
   setcode do
-    Puppet.settings['server'] != Puppet.settings['node_name_value']
+    if Facter.value(:os)['family'].eql?('RedHat') || Facter.value(:os)['family'].eql?('Suse')
+      Dir['/etc/sysconfig/*puppetserver'].empty?
+    else
+      Dir['/etc/default/*puppetserver'].empty?
+    end
   end
 end


### PR DESCRIPTION
# Summary

The `splunk_hec_agent_only_node` fact was flawed, in that it improperly resolved to **true** on infrastructure nodes (compilers, replica). This is caused by the fact previously checking if there was a difference between the server setting
and the current nodes certname.

# Detailed Description

As compilers and replicas have Puppet Server running, but still report to the Primary the fact is incorrectly resolving to true, indicating the node is only running the Puppet agent.

The changes in this PR determines which OS the node is running, then will check the appropriate directory for the Puppet Server service file.

# Checklist

[X] PR title is "(Ticket|Maint) Short Description"
[X] Commit title matches PR title
