### PR TITLE
(PIE-1039) Update deprecated reports parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to this project will be documented in this file. The format 
 
 - Prevent the `event_types` parameter from being configured unless `events_reporting_enabled` is set to **true**. [#174](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/174)
 
+- The `splunk_hec_agent_only_node` fact now properly resolves to **false** on infrastructure nodes running Puppet Server. [#175](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/175)
+
+- Prevent the deprecated `reports` parameter from removing configured settings in `puppet.conf`. [#176](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/176)
+
 ## [v1.1.0](https://github.com/puppetlabs/puppetlabs-splunk_hec/tree/v1.1.0) (2021-11-09)
 
 [Full Changelog](https://github.com/puppetlabs/puppetlabs-splunk_hec/compare/v1.0.1..v1.1.0)

--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ To set up a testing environment with fips enabled, run the following command: `P
   * Integration with the `puppet_metrics_collection` requires version `>= 6.0.0`.
   * SSL Validation is under active development and behavior may change.
   * Automated testing could use work.
+  * `>= 0.9.0` With the deprecated `reports` parameter set to an empty string, any values in the reports settings in `puppet.conf` are removed.
 
 ## Breaking Changes
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -151,34 +151,24 @@ class splunk_hec (
   }
 
   if $enable_reports {
+  # lint:ignore:140chars
     if $reports != undef  {
       notify { 'reports param deprecation warning' :
-        message  => "The 'reports' parameter is being deprecated in favor of having the module automatically add the 'splunk_hec' setting \
-        to puppet.conf. You can enable this behavior by setting 'reports' to '', the empty string, but please keep in mind that the \
-        'reports' parameter will be removed in a future release.",
+        message  => 'The reports parameter has been deprecated in favor of having the module automatically add the splunk_hec setting to puppet.conf. Update the reports param to undef or remove it entirely. Please note that the reports parameter is currently ignored and will be removed in a future release of this module.',
         loglevel =>  'warning',
       }
-
-      Resource[$ini_setting] {'enable splunk_hec':
-        ensure  => present,
-        path    => '/etc/puppetlabs/puppet/puppet.conf',
-        section => 'master',
-        setting => 'reports',
-        value   => $reports,
-        notify  => Service[$service],
-      }
-    } else {
-      # The subsetting resource automatically adds the 'splunk_hec' report
-      # processor to the reports setting if it hasn't yet been added there.
-      Resource[$ini_subsetting] { 'enable splunk_hec':
-        ensure               => present,
-        path                 => '/etc/puppetlabs/puppet/puppet.conf',
-        section              => 'master',
-        setting              => 'reports',
-        subsetting           => 'splunk_hec',
-        subsetting_separator => ',',
-        notify               => Service[$service],
-      }
+    }
+  # lint:endignore
+    # The subsetting resource automatically adds the 'splunk_hec' report
+    # processor to the reports setting if it hasn't yet been added there.  
+    Resource[$ini_subsetting] { 'enable splunk_hec':
+      ensure               => present,
+      path                 => '/etc/puppetlabs/puppet/puppet.conf',
+      section              => 'master',
+      setting              => 'reports',
+      subsetting           => 'splunk_hec',
+      subsetting_separator => ',',
+      notify               => Service[$service],
     }
   }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -106,7 +106,7 @@ describe 'splunk_hec' do
         it { is_expected.to have_pe_ini_subsetting_resource_count(1) }
       end
 
-      context "set 'reports' setting to $reports if $reports != ''" do
+      context "does not set 'reports' setting to $reports when $reports != undef" do
         let(:params) do
           p = super()
           p['reports'] = 'foo,bar,baz'
@@ -114,8 +114,9 @@ describe 'splunk_hec' do
         end
 
         it { is_expected.to contain_notify('reports param deprecation warning') }
-        it { is_expected.to contain_pe_ini_setting('enable splunk_hec').with_value('foo,bar,baz') }
-        it { is_expected.to have_pe_ini_subsetting_resource_count(0) }
+        it { is_expected.to contain_pe_ini_subsetting('enable splunk_hec').with_subsetting('splunk_hec') }
+        it { is_expected.to have_pe_ini_setting_resource_count(0) }
+        it { is_expected.to have_pe_ini_subsetting_resource_count(1) }
       end
     end
 


### PR DESCRIPTION
# Summary

Prior to this commit, the suggestion of setting the `splunk_hec::reports` parameter to an empty string results in corrective changes as it removes **puppetdb** from the reports setting.

# Detailed Description

The new logic in `init.pp` prevents the `reports` parameter from configuring anything before throwing an updated warning message suggesting to set the parameter to `undef` or remove it entirely. It then will continue with adding `splunk_hec` to `puppet.conf` via the `ini_subsetting` resource.

# Checklist

[X] Ensure README is updated
  [X] Anything new added
[X] PR title is "(Ticket|Maint) Short Description"
[X] Commit title matches PR title
