### PR TITLE
PIE-1047 Account for negative indicies

### DIFF
--- a/files/splunk_hec.rb
+++ b/files/splunk_hec.rb
@@ -12,7 +12,9 @@ data_to_send = ''
 EVENT_SOURCETYPE = INDICES.select { |index| settings['event_types'].include? index }
 
 EVENT_SOURCETYPE.each_key do |index|
-  next unless data[index]
+  # A nil value indicates that there were no new events.
+  # A negative value indicates that the sourcetype has been disabled from the pe_event_forwarding module.
+  next if data[index].nil? || data[index] == -1
   data_to_send << extract_events(data[index], INDICES[index], settings["#{index}_data_filter"])
 end
 


### PR DESCRIPTION
pe_event_forwarding will soon have the ability to disable rbac event
collection for performance reasons. The is denoted in the index file
with a -1 value. We need to cover the case where rbac events are
enabled in splunk_hec but disabled in pe_event_forwarding. This check
will skip indicies with negative values.

# Summary

# Detailed Description

<!--
As you complete items on the checklist, squash and push the new commits and
check the boxes below. The expectation is that a PR will go up early, before the
work is done and new commits will be squashed and pushed and boxes will get
checked as work continues.
-->

# Checklist

[ ] Draft PR?
[ ] Ensure README is updated
  [ ] Any changes to existing documentation
  [ ] Anything new added
  [ ] Link to external Puppet documentation
  [ ] Review [Support Playbook](https://confluence.puppetlabs.com/display/SUP/Splunk+HEC+Module+Support+Playbook) for any needed updates
[ ] Tags
[ ] Unit Tests
[ ] Acceptance Tests
[ ] PR title is "(Ticket|Maint) Short Description"
[ ] Commit title matches PR title
