### PR TITLE
PIE-1032 Account for configured confdirs

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -215,7 +215,12 @@ class splunk_hec (
   }
 
   if $events_reporting_enabled {
-    $confdir_base_path = pe_event_forwarding::base_path($settings::confdir, undef)
+    if $pe_event_forwarding::confdir != undef {
+      $confdir_base_path = $pe_event_forwarding::confdir
+    }
+    else {
+      $confdir_base_path = pe_event_forwarding::base_path($settings::confdir, undef)
+    }
 
     file { "${confdir_base_path}/pe_event_forwarding/processors.d/splunk_hec":
       ensure  => directory,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -51,7 +51,9 @@ describe 'splunk_hec' do
       }
     }
 
-    class pe_event_forwarding () {}
+    class pe_event_forwarding (
+      Optional[String] $confdir = "/tmp",
+    ) {}
 
     class {pe_event_forwarding:}
     MANIFEST
@@ -64,7 +66,7 @@ describe 'splunk_hec' do
     }
   end
 
-  let(:confdir) { Dir.pwd }
+  let(:confdir) { '/tmp' }
   let(:event_forwarding_base) { "#{confdir}/pe_event_forwarding/processors.d" }
   let(:facts) do
     {


### PR DESCRIPTION
The init.pp now accounts for customized confdirs from the
pe_event_forwarding module and places the proc files within the correct
directories.

# Summary

# Detailed Description

<!--
As you complete items on the checklist, squash and push the new commits and
check the boxes below. The expectation is that a PR will go up early, before the
work is done and new commits will be squashed and pushed and boxes will get
checked as work continues.
-->

# Checklist

[ ] Draft PR?
[ ] Ensure README is updated
  [ ] Any changes to existing documentation
  [ ] Anything new added
  [ ] Link to external Puppet documentation
  [ ] Review [Support Playbook](https://confluence.puppetlabs.com/display/SUP/Splunk+HEC+Module+Support+Playbook) for any needed updates
[ ] Tags
[ ] Unit Tests
[ ] Acceptance Tests
[ ] PR title is "(Ticket|Maint) Short Description"
[ ] Commit title matches PR title
