### PR TITLE
(PIE-1102) Send only changed reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,13 @@ By default this type of reporting is not enabled.
   * `true`
   * `false`
 
+##### only_changes
+
+`Boolean`: Only process reports when the report status indicates there were [changes](https://puppet.com/docs/puppet/latest/format_report.html#format_report-puppet-transaction-report).
+
+  * `true`
+  * `false` :: **Default Value**
+
 ##### summary_resources_format
 
 `String`: If `include_resources_corrective_change` or `include_resources_status` is set and therefore `resource_events` are being sent as part of `puppet:summary` events, we can choose what format they should be sent in. Depending on your usage within Splunk, different formats may be preferable. The possible values are:

--- a/lib/puppet/reports/splunk_hec.rb
+++ b/lib/puppet/reports/splunk_hec.rb
@@ -8,8 +8,14 @@ Puppet::Reports.register_report(:splunk_hec) do
   def process
     # This prevents the processor from running if disabled
     return 0 if settings['disabled']
-    # now we can create the event with the timestamp from the report
 
+    # This prevents the processor from running when there are no changes to the report
+    if settings['only_changes'] && (status != 'changed')
+      Puppet.warning "Not submitting report to Splunk, report contains no changes! Status: #{status}"
+      return 0
+    end
+
+    # now we can create the event with the timestamp from the report
     epoch = sourcetypetime(time, metrics['time']['total'])
 
     # pass simple metrics for report processing later

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,8 @@
 #   If set to true, will call store_event and save report as json
 # @param [Boolean] disabled
 #   Disables the splunk_hec report processor
+# @param [Boolean] only_changes
+#   When true, only reports with a changed status with be send to Splunk
 # @param [Boolean] manage_routes
 #   When false, will not automatically send facts to splunk_hec
 # @param [Boolean] events_reporting_enabled
@@ -105,6 +107,7 @@ class splunk_hec (
   Boolean $enable_reports                                = false,
   Boolean $record_event                                  = false,
   Boolean $disabled                                      = false,
+  Boolean $only_changes                                  = false,
   Boolean $manage_routes                                 = false,
   Boolean $events_reporting_enabled                      = false,
   String $facts_terminus                                 = 'puppetdb',

--- a/templates/splunk_hec.yaml.epp
+++ b/templates/splunk_hec.yaml.epp
@@ -72,6 +72,9 @@
 <% if $splunk_hec::disabled { -%>
 "disabled" : "<%= $splunk_hec::disabled %>"
 <% } -%>
+<% if $splunk_hec::only_changes { -%>
+"only_changes" : "<%= $splunk_hec::only_changes %>"
+<% } -%>
 <% if $splunk_hec::events_reporting_enabled { -%>
 "events_reporting_enabled" : "<%= $splunk_hec::events_reporting_enabled %>"
 "event_types" : "<%= $splunk_hec::event_types %>"


### PR DESCRIPTION
# Summary

A commonly requested feature for this module is the ability to send only reports that contain changes. This commit adds the ability to configure this type of functionality.

# Detailed Description

  * Adding the new boolean parameter `splunk_hec::only_changes` to `init.pp`.
  * When configured adding the setting to `splunk_hec.yaml`.
    * Adding logic to `lib/puppet/reports/splunk_hec.rb` preventing report processing when the report status has not changed. 
  * Updated **Customized Reporting** section in the `README`.

# Checklist

[X] Ensure README is updated
  [X] Any changes to existing documentation
  [X] Anything new added
  [X] Link to external Puppet documentation
  [ ] Review [Support Playbook](https://confluence.puppetlabs.com/display/SUP/Splunk+HEC+Module+Support+Playbook) for any needed updates
[ ] Unit Tests
[X] PR title is "(Ticket|Maint) Short Description"
[X] Commit title matches PR title
