### PR TITLE
(PIE-1279) Update deprecated Splunk endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,14 @@ on: [push, pull_request]
 
 jobs:
   Spec:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         check: ['syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop parallel_spec']
         ruby_version: [2.7.x]
         puppet_gem_version: [~> 6.0]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
 
     - uses: actions/setup-ruby@v1
       with:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -44,7 +44,7 @@ jobs:
           echo STEP_ID=${{ matrix.platform }}-${{ matrix.puppet_version }}-1 >> $GITHUB_ENV
           echo STEP_START=$(date +%s) >> $GITHUB_ENV
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Activate Ruby 2.7
         uses: ruby/setup-ruby@v1

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -148,7 +148,7 @@ def get_splunk_report(earliest, latest, sourcetype = 'puppet:summary')
   start_time =  earliest.strftime('%m/%d/%Y:%H:%M:%S')
   end_time   = (latest + 2).strftime('%m/%d/%Y:%H:%M:%S')
   query_command = 'curl -u admin:piepiepie -k '\
-    'https://localhost:8089/services/search/jobs/export -d output_mode=json '\
+    'https://localhost:8089/services/search/v2/jobs/export -d output_mode=json '\
     "-d search='search sourcetype=\"#{sourcetype}\" AND earliest=\"#{start_time}\" AND latest=\"#{end_time}\"'"
   sleep 1
   begin


### PR DESCRIPTION
# Summary

While working on PIE-1181 I found that the endpoint utilizes to retrieve events from Splunk has been marked as deprecated. This PR updates that endpoint.

# Detailed Description

  * Updated endpoint to **v2** in `get_splunk_report()` within the `spec_helper_acceptance_local.rb` file.


# Checklist
[X] Acceptance Tests
[X] PR title is "(Ticket|Maint) Short Description"
[X] Commit title matches PR title
