### PR TITLE
(PIE-1289) Event Filtering Bug Fix

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -17,10 +17,7 @@ jobs:
         puppet_version:
           - puppet6-nightly
           - puppet7-nightly
-          - 2019.8.7
-          - 2019.8.8
-          - 2019.8.9
-          - 2019.8.10
+          - 2021.7.2
 
     env:
       BUILDEVENT_FILE: "../buildevents.txt"

--- a/plans/acceptance/pe_server_setup.pp
+++ b/plans/acceptance/pe_server_setup.pp
@@ -11,8 +11,8 @@
 # @param [Optional[Hash]] pe_settings
 #   Sets PE settings including password
 plan splunk_hec::acceptance::pe_server_setup(
-  Optional[String] $version = '2019.8.7',
-  Optional[Hash] $pe_settings = {password => 'puppetlabs'}
+  Optional[String] $version = '2021.7.2',
+  Optional[Hash] $pe_settings = {password => 'puppetlabspie'}
 ) {
   # machines are not yet ready at time of installing the puppetserver, so we wait 15s
   $localhost = get_targets('localhost')
@@ -30,8 +30,7 @@ plan splunk_hec::acceptance::pe_server_setup(
   )
 
   $cmd = @("CMD")
-          puppet infra console_password --password=pie
-          echo 'pie' | puppet access login --lifetime 1y --username admin
+          echo 'puppetlabspie' | puppet access login -l 1y --username admin
           puppet infrastructure tune | sed "s,\\x1B\\[[0-9;]*[a-zA-Z],,g" > /etc/puppetlabs/code/environments/production/data/common.yaml
           puppet agent -t
           | CMD

--- a/spec/acceptance/events_processor_spec.rb
+++ b/spec/acceptance/events_processor_spec.rb
@@ -12,7 +12,7 @@ describe 'Event Forwarding' do
     context 'with orchestrator event_types set' do
       let(:report) do
         before_run = Time.now.utc
-        puppetserver.run_shell("puppet task run facts --nodes #{host_name}")
+        puppetserver.run_shell("LC_ALL=en_US.UTF-8 puppet task run facts --nodes #{host_name}")
         puppetserver.run_shell("#{EVENT_FORWARDING_CONFDIR}/collect_api_events.rb")
         after_run = Time.now.utc
         get_splunk_report(before_run, after_run, 'puppet:jobs')
@@ -43,29 +43,57 @@ describe 'Event Forwarding' do
         expect(event['options']['transport']).to      be_nil
       end
     end
-  end
 
-  context 'with rbac event_types set' do
-    it 'does not send report on first run'
-    it 'Successfully sends an RBAC event to splunk'
-    it 'Sets event properties correctly'
-  end
+    context 'with rbac event_types set' do
+      it 'does not send report on first run'
+      it 'Successfully sends an RBAC event to splunk'
+      it 'Sets event properties correctly'
+    end
 
-  context 'with classifier event_types set' do
-    it 'does not send report on first run'
-    it 'Successfully sends a classifier event to splunk'
-    it 'Sets event properties correctly'
-  end
+    context 'with classifier event_types set' do
+      it 'does not send report on first run'
+      it 'Successfully sends a classifier event to splunk'
+      it 'Sets event properties correctly'
+    end
 
-  context 'with pe_console event_types set' do
-    it 'does not send report on first run'
-    it 'Successfully sends a PE console event to splunk'
-    it 'Sets event properties correctly'
-  end
+    context 'with pe_console event_types set' do
+      let(:report) do
+        before_run = Time.now.utc
+        puppetserver.run_shell("LC_ALL=en_US.UTF-8 puppet task run facts --nodes #{host_name}")
+        puppetserver.run_shell("#{EVENT_FORWARDING_CONFDIR}/collect_api_events.rb")
+        after_run = Time.now.utc
+        get_splunk_report(before_run, after_run, 'puppet:activities_console')
+      end
 
-  context 'with code_manager event_types set' do
-    it 'does not send report on first run'
-    it 'Successfully sends a code manager event to splunk'
-    it 'Sets event properties correctly'
+      it 'does not send report on first run' do
+        puppetserver.run_shell('rm /etc/puppetlabs/pe_event_forwarding/pe_event_forwarding_indexes.yaml', expect_failures: true)
+        count = report_count(report)
+        expect(count).to be 0
+      end
+
+      it 'Successfully sends a pe_console event to splunk' do
+        # ensure the indexes.yaml file is created
+        puppetserver.run_shell("#{EVENT_FORWARDING_CONFDIR}/collect_api_events.rb")
+        count = report_count(report)
+        expect(count).to be 1
+      end
+
+      it 'Sets event properties correctly' do
+        data   = report[0]['result']
+        event  = JSON.parse(data['_raw'])
+
+        expect(data['source']).to             eql('http:splunk_hec_token')
+        expect(data['sourcetype']).to         eql('puppet:activities_console')
+        expect(event['events'][0]['type']).to eql('run_task')
+        expect(event['subject']['blah']).to   be_nil
+        expect(event['subject']['name']).to   eql('admin')
+      end
+    end
+
+    context 'with code_manager event_types set' do
+      it 'does not send report on first run'
+      it 'Successfully sends a code manager event to splunk'
+      it 'Sets event properties correctly'
+    end
   end
 end

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -107,6 +107,7 @@ def setup_manifest(disabled: false, url: nil, with_event_forwarding: false)
     manifest << add_event_forwarding
     params[:events_reporting_enabled] = true
     params[:orchestrator_data_filter] = ['options.scope.nodes', 'options.scope.blah', 'environment.name']
+    params[:pe_console_data_filter]   = ['subject.name', 'subject.blah', 'events']
   end
 
   manifest << declare(:class, :splunk_hec, params)

--- a/templates/splunk_hec.yaml.epp
+++ b/templates/splunk_hec.yaml.epp
@@ -98,13 +98,13 @@
 <% } -%>
 <% } -%>
 <% if $splunk_hec::pe_console_data_filter { -%>
-"pe_console_data_filter" :
+"pe-console_data_filter" :
 <% $splunk_hec::pe_console_data_filter.each |$subset| {-%>
         - <%= $subset %>
 <% } -%>
 <% } -%>
 <% if $splunk_hec::code_manager_data_filter { -%>
-"code_manager_data_filter" :
+"code-manager_data_filter" :
 <% $splunk_hec::code_manager_data_filter.each |$subset| {-%>
         - <%= $subset %>
 <% } -%>


### PR DESCRIPTION
# Summary

While setting up rspec tests I found that filtering does not work for `pe-console` and `code-manager`. This is a result of the processor script looking for `splunk_hec` settings named `pe-console_data_filter` and `code-manager_data_filter` when the template file for settings has the them named `pe_console_data_filter` and `code_manager_data_filter`.

# Detailed Description

  * Update `templates/splunk_hec.yaml.epp` with correct setting names.
  * Add tests for `pe-console` events:
    * `spec/acceptance/events_processor_spec.rb`
    * `spec/spec_helper_acceptance_local.rb`
  * Update `.github/workflows/integration_test.yml` to test on PE LTS.


# Checklist
[X] Acceptance Tests
[X] PR title is "(Ticket|Maint) Short Description"
[X] Commit title matches PR title
