### PR TITLE
(PIE-1278) Add facts spec test

### DIFF
--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -17,7 +17,13 @@ describe 'Verify the minimum install' do
       expect(report_count).to be 1
     end
 
-    it 'Successfully sends facts to Splunk'
+    it 'Successfully sends facts to Splunk' do
+      before_run = earliest
+      trigger_puppet_run(puppetserver)
+      after_run = Time.now.utc
+      report_count = report_count(get_splunk_report(before_run, after_run, 'puppet:facts'))
+      expect(report_count).to be >= 1
+    end
 
     it 'Records events with record_event set to true'
 

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -93,15 +93,12 @@ def setup_manifest(disabled: false, url: nil, with_event_forwarding: false)
     url:            url,
     token:          'abcd1234',
     enable_reports: true,
+    manage_routes: true,
+    facts_terminus: 'yaml',
     record_event:   true,
     pe_console:     'localhost',
     disabled:       disabled,
   }
-
-  unless puppet_user == 'pe-puppet'
-    params[:manage_routes] = true
-    params[:facts_terminus] = 'yaml'
-  end
 
   if with_event_forwarding
     manifest << add_event_forwarding


### PR DESCRIPTION
# Summary

This commit tests against the ability to send Puppet facts to Splunk.

# Detailed Description

`spec/acceptance/class_spec.rb`
  * Added test for Puppet facts.

`spec/spec_helper_acceptance_local.rb`
  * Ensure fact configuration is set in the manifest.

# Checklist

[X] Acceptance Tests
[X] PR title is "(Ticket|Maint) Short Description"
[X] Commit title matches PR title
