### PR TITLE
(PIE-1329) Secure sensitive data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased](https://github.com/puppetlabs/puppetlabs-splunk_hec)
 
+### Added
+
+Credential data provided to this module is now written to a separate configuration file utilizing the Sensitive data type to ensure redaction from Puppet logs and reports. [#204](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/204)
+
+Configuration files created by this module are now placed in a `splunk_hec` subdirectory. [#204](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/204)
+
+New private subclass `splunk_hec::v2_cleanup` ensures old configuration files are removed. [#204](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/204)
+
+New custom function to convert sensitive user provided data from a String to Puppet's [Sensitive](https://www.puppet.com/docs/puppet/latest/lang_data_sensitive.html) data type. [#203](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/203)
+
+Add support for Puppet 8. [#200](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/200)
+
 ### Fixed
 
 Settings are now removed from `puppet.conf` when `splunk_hec::disabled` is set to **true**.[#205](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/205)

--- a/README.md
+++ b/README.md
@@ -201,12 +201,6 @@ Alternatively, you can create a [profile class](https://puppet.com/docs/pe/lates
 
 ```
 class profile::splunk_hec {
-  file { '/etc/puppetlabs/puppet/splunk_hec':
-    ensure => directory,
-    owner  => 'pe-puppet',
-    group  => 'pe-puppet',
-    mode   => 0644,
-  }
   file { '/etc/puppetlabs/puppet/splunk_hec/splunk_ca.cert':
     ensure => file,
     owner  => 'pe-puppet',

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6,7 +6,17 @@
 
 ### Classes
 
+#### Public Classes
+
 * [`splunk_hec`](#splunk_hec): Simple class to manage your splunk_hec connectivity
+
+#### Private Classes
+
+* `splunk_hec::v2_cleanup`: Class to remove old configuration files
+
+### Functions
+
+* [`splunk_hec::secure`](#splunk_hecsecure): Custom function to mark sensitive data utilized by this module as Sensitive types in the Puppet language. Sensitive data is redacted from Pup
 
 ### Plans
 
@@ -48,6 +58,9 @@ The following parameters are available in the `splunk_hec` class:
 - [Reference](#reference)
   - [Table of Contents](#table-of-contents)
     - [Classes](#classes)
+      - [Public Classes](#public-classes)
+      - [Private Classes](#private-classes)
+    - [Functions](#functions)
     - [Plans](#plans)
       - [Public Plans](#public-plans)
       - [Private Plans](#private-plans)
@@ -108,9 +121,10 @@ The url of the server that PE is running on
 
 ##### <a name="-splunk_hec--token"></a>`token`
 
-Data type: `String`
+Data type: `Optional[String]`
 
-The user token
+The default Splunk HEC token
+Note: The value of the token is converted to Puppet's Sensitive data type during catalog application.
 
 ##### <a name="-splunk_hec--collect_facts"></a>`collect_facts`
 
@@ -261,6 +275,7 @@ Data type: `Optional[String]`
 
 Corresponds to puppet:summary in the Puppet Report Viewer
 When storing summary in a different index than the default token
+Note: The value of the token is converted to Puppet's Sensitive data type during catalog application.
 
 Default value: `undef`
 
@@ -270,6 +285,7 @@ Data type: `Optional[String]`
 
 Corresponds to puppet:facts in the Puppet Report Viewer
 When storing facts in a different index than the default token
+Note: The value of the token is converted to Puppet's Sensitive data type during catalog application.
 
 Default value: `undef`
 
@@ -279,6 +295,7 @@ Data type: `Optional[String]`
 
 Corresponds to puppet:metrics in the Puppet Report Viewer
 When storing metrics in a different index than the default token
+Note: The value of the token is converted to Puppet's Sensitive data type during catalog application.
 
 Default value: `undef`
 

--- a/files/hec_secrets.yaml.epp
+++ b/files/hec_secrets.yaml.epp
@@ -1,0 +1,19 @@
+<%- | Optional[Sensitive[String]] $token = undef, 
+      Optional[Sensitive[String]] $token_summary = undef,
+      Optional[Sensitive[String]] $token_facts = undef,
+      Optional[Sensitive[String]] $token_metrics = undef
+| -%>
+# managed by splunk_hec module
+---
+<% if $token { -%>
+"token" : "<%= $token %>"
+<% } -%>
+<% if $token_summary { -%>
+"token_summary" : "<%= $token_summary %>"
+<% } -%>
+<% if $token_facts { -%>
+"token_facts" : "<%= $token_facts %>"
+<% } -%>
+<% if $token_metrics { -%>
+"token_metrics" : "<%= $token_metrics %>"
+<% } -%>

--- a/lib/puppet/functions/splunk_hec/secure.rb
+++ b/lib/puppet/functions/splunk_hec/secure.rb
@@ -3,10 +3,15 @@
 # Sensitive data is redacted from Puppet logs and reports.
 Puppet::Functions.create_function(:'splunk_hec::secure') do
   dispatch :secure do
-    param 'String', :secret
+    param 'Hash', :secrets
   end
 
-  def secure(secret)
-    Puppet::Pops::Types::PSensitiveType::Sensitive.new(secret)
+  def secure(secrets)
+    secrets.each do |key, value|
+      unless value.nil?
+        secrets[key] = Puppet::Pops::Types::PSensitiveType::Sensitive.new(value)
+      end
+    end
+    secrets
   end
 end

--- a/lib/puppet/util/splunk_hec.rb
+++ b/lib/puppet/util/splunk_hec.rb
@@ -12,9 +12,16 @@ require 'time'
 module Puppet::Util::Splunk_hec
   def settings
     return @settings if @settings
-    @settings_file = Puppet[:confdir] + '/splunk_hec.yaml'
+    @settings_file = Puppet[:confdir] + '/splunk_hec/settings.yaml'
 
     @settings = YAML.load_file(@settings_file)
+  end
+
+  def secrets
+    return @secrets if @secrets
+    @secrets_file = Puppet[:confdir] + '/splunk_hec/hec_secrets.yaml'
+
+    @secrets = YAML.load_file(@secrets_file)
   end
 
   def build_ca_store(cert_store_file_path)
@@ -86,7 +93,7 @@ module Puppet::Util::Splunk_hec
     # we want users to be able to provide different tokens per sourcetype if they want
     source_type = body['sourcetype'].split(':')[1]
     token_name = "token_#{source_type}"
-    token = settings[token_name] || settings['token'] || raise(Puppet::Error, 'Must provide token parameter to splunk class')
+    token = settings[token_name] || secrets['token'] || raise(Puppet::Error, 'Must provide token parameter to splunk class')
     if settings['fips_enabled']
       send_with_fips(body, source_type, token)
     else

--- a/manifests/v2_cleanup.pp
+++ b/manifests/v2_cleanup.pp
@@ -1,0 +1,17 @@
+# @summary Class to remove old configuration files
+#
+# @api private
+#
+# Private subclass to remove configurations utilized by v1 of this module
+#
+# @example
+#   include splunk_hec::v2_cleanup
+class splunk_hec::v2_cleanup {
+  file { "${settings::confdir}/splunk_hec.yaml":
+    ensure  => absent,
+  }
+
+  file { "${settings::confdir}/splunk_hec_routes.yaml":
+    ensure  => absent,
+  }
+}

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -198,7 +198,14 @@ describe 'splunk_hec' do
       it { is_expected.to have_pe_ini_setting_resource_count(0)    }
       it { is_expected.to have_pe_ini_subsetting_resource_count(0) }
       it {
-        is_expected.to contain_file("#{confdir}/splunk_hec.yaml")
+        is_expected.to contain_file("#{confdir}/splunk_hec/settings.yaml")
+          .with(
+            owner: 'root',
+            group: 'root',
+          )
+      }
+      it {
+        is_expected.to contain_file("#{confdir}/splunk_hec/hec_secrets.yaml")
           .with(
             owner: 'root',
             group: 'root',

--- a/spec/support/unit/reports/splunk_hec_spec_helpers.rb
+++ b/spec/support/unit/reports/splunk_hec_spec_helpers.rb
@@ -57,7 +57,7 @@ def default_settings_hash
 end
 
 def mock_settings_file(settings_hash)
-  allow(YAML).to receive(:load_file).with(%r{splunk_hec\.yaml}).and_return(settings_hash)
+  allow(YAML).to receive(:load_file).with(%r{(.*)(settings|hec_secrets).yaml}).and_return(settings_hash)
 end
 
 def new_mock_response(status, body)

--- a/templates/settings.yaml.epp
+++ b/templates/settings.yaml.epp
@@ -1,7 +1,6 @@
-# managed by puppet
+# managed by splunk_hec module
 ---
 "url" : "<%= $splunk_hec::url %>"
-"token" : "<%= $splunk_hec::token %>"
 "facts.allowlist" :
 <% $splunk_hec::collect_facts.each |$fact| {-%>
         - <%= $fact %>
@@ -26,15 +25,6 @@
 <% } -%>
 <% if $splunk_hec::record_event { -%>
 "record_event" : "<%= $splunk_hec::record_event %>"
-<% } -%>
-<% if $splunk_hec::token_summary { -%>
-"token_summary" : "<%= $splunk_hec::token_summary %>"
-<% } -%>
-<% if $splunk_hec::token_facts { -%>
-"token_facts" : "<%= $splunk_hec::token_facts %>"
-<% } -%>
-<% if $splunk_hec::token_metrics { -%>
-"token_metrics" : "<%= $splunk_hec::token_metrics %>"
 <% } -%>
 <% if $splunk_hec::url_summary { -%>
 "url_summary" : "<%= $splunk_hec::url_summary %>"

--- a/templates/util_splunk_hec.erb
+++ b/templates/util_splunk_hec.erb
@@ -16,7 +16,7 @@ class ::Hash
   end
 end
 
-@confdir  = '/etc/puppetlabs/puppet'
+@confdir  = '/etc/puppetlabs/puppet/splunk_hec'
 
 INDICES = {
   'orchestrator' => 'puppet:jobs',
@@ -26,10 +26,15 @@ INDICES = {
   'code-manager' => 'puppet:activities_code_manager'
 }
 
-@settings_file = "#{@confdir}/splunk_hec.yaml"
+@settings_file = "#{@confdir}/settings.yaml"
+@secrets_file = "#{@confdir}/hec_secrets.yaml"
 
 def settings
   @settings ||= YAML.load_file(@settings_file)
+end
+
+def secrets
+  @secrets ||= YAML.load_file(@secrets_file)
 end
 
 def build_ca_store(cert_store_file_path)
@@ -77,7 +82,7 @@ def submit_request(body)
   source_type = 'pe_event_forwarding'
   token_name = "token_#{source_type}"
   http = create_http(source_type)
-  token = settings[token_name] || settings['token'] || raise('Must provide token parameter to splunk class')
+  token = secrets[token_name] || secrets['token'] || raise('Must provide token parameter to splunk class')
   req = Net::HTTP::Post.new(@uri.path.to_str)
   req.add_field('Authorization', "Splunk #{token}")
   req.add_field('Content-Type', 'application/json')


### PR DESCRIPTION
# Summary

This PR utilizes the custom function `splunk_hec::secure` to move credential data to a separate file under a new `splunk_hec` subdir.

# Detailed Description

  * Added `manifests/v2_cleanup.pp`
  * Added `files/hec_secrets.yaml.epp`
  * Renamed `templates/splunk_hec.yaml.epp` -> `templates/settings.yaml.epp`
  * Updated `lib/puppet/functions/splunk_hec/secure.rb`
    * Function now accepts and returns a hash instead of string
  * Updated `manifests/init.pp`
    * Create `/etc/puppetlabs/puppet/splunk_hec` directory for config files. 
    * Move credentials to `hec_secrets.yaml`
    * Remove `splunk_hec.yaml` via `::v2_cleanup` subclass
    * Remove `splunk_hec_routes.yaml` via `::v2_cleanup` subclass
  * Updated `lib/puppet/util/splunk_hec.rb`
    * Utilize credentials from `hec_secrets.yaml`
  * Updated `templates/util_splunk_hec.erb`
    * Utilize credentials from `hec_secrets.yaml`

# Checklist

[X] Ensure README is updated
[X] Any changes to existing documentation
[X] Anything new added
[X] Link to external Puppet documentation
[X] PR title is "(Ticket|Maint) Short Description"
[X] Commit title matches PR title
