### PR TITLE
(PIE-1104) Disable facts and reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased](https://github.com/puppetlabs/puppetlabs-splunk_hec)
 
+### Fixed
+
+Settings are now removed from `puppet.conf` when `splunk_hec::disabled` is set to **true**.[#205](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/205)
+
 ## [v1.4.0](https://github.com/puppetlabs/puppetlabs-splunk_hec/tree/v1.4.0) (2023-4-17)
 
 [Full Changelog](https://github.com/puppetlabs/puppetlabs-splunk_hec/compare/v1.3.0..v1.4.0)

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -140,7 +140,7 @@ Default value: `false`
 
 Data type: `Boolean`
 
-Disables the splunk_hec report processor
+Removes settings to send reports and facts to Splunk
 
 Default value: `false`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,7 +19,7 @@
 # @param [Boolean] record_event
 #   If set to true, will call store_event and save report as json
 # @param [Boolean] disabled
-#   Disables the splunk_hec report processor
+#   Removes settings to send reports and facts to Splunk
 # @param [Boolean] only_changes
 #   When true, only reports with a changed status with be send to Splunk
 # @param [Boolean] manage_routes
@@ -161,6 +161,13 @@ class splunk_hec (
     $group          = 'puppet'
   }
 
+  unless $disabled {
+    $ensure_conf = present
+  }
+  else {
+    $ensure_conf = absent
+  }
+
   if $enable_reports {
     # lint:ignore:140chars
     if $reports != undef {
@@ -173,7 +180,7 @@ class splunk_hec (
     # The subsetting resource automatically adds the 'splunk_hec' report
     # processor to the reports setting if it hasn't yet been added there.  
     Resource[$ini_subsetting] { 'enable splunk_hec':
-      ensure               => present,
+      ensure               => $ensure_conf,
       path                 => '/etc/puppetlabs/puppet/puppet.conf',
       section              => 'master',
       setting              => 'reports',
@@ -193,7 +200,7 @@ class splunk_hec (
       notify  => Service[$service],
     }
     Resource[$ini_setting] { 'enable splunk_hec_routes.yaml':
-      ensure  => present,
+      ensure  => $ensure_conf,
       path    => '/etc/puppetlabs/puppet/puppet.conf',
       section => 'master',
       setting => 'route_file',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -126,10 +126,15 @@ describe 'splunk_hec' do
       let(:params) do
         p = super()
         p['disabled'] = true
+        p['enable_reports'] = true
+        p['manage_routes'] = true
         p
       end
 
-      it { is_expected.to compile }
+      it { is_expected.to contain_pe_ini_subsetting('enable splunk_hec').with_setting('reports').with_ensure('absent') }
+      it { is_expected.to contain_pe_ini_setting('enable splunk_hec_routes.yaml').with_setting('route_file').with_ensure('absent') }
+      it { is_expected.to have_pe_ini_subsetting_resource_count(1) }
+      it { is_expected.to have_pe_ini_setting_resource_count(1) }
     end
 
     context 'events_reporting_enabled' do


### PR DESCRIPTION
# Summary

This PR ensures that settings added to `puppet.conf` are removed when `splunk_hec::disabled` to set to **true**.

# Detailed Description

  * Update `manifests/init.pp` to ensure settings are removed from `puppet.conf` when disabled is true.
  * Added unit tests to `spec/classes/init_spec.rb`
  * Generated updates for `REFERENCE.md`.
  * Add changes to `CHANGELOG.md`.

# Checklist

[X] Any changes to existing documentation
[X] Unit Tests
[X] PR title is "(Ticket|Maint) Short Description"
[X] Commit title matches PR title