### PR TITLE
(PIE-1374) Refactor metrics parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Fixed
 
+- No longer utilizing `parse_legacy_metrics` function for metrics collected with older versions of `puppet_metrics_collector`. [#211](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/211)
+
 - False positive when attempting to rescue required facts from an unconfigured  `splunk_hec::facts_blocklist`. [#210](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/210)
 
 - Settings are now removed from `puppet.conf` when `splunk_hec::disabled` is set to **true**. [#205](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/205)

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-puppet_metrics_collector",
-      "version_requirement": ">= 6.0.0 < 9.0"
+      "version_requirement": ">= 6.0.0 < 9.0.0"
     },
     {
       "name": "puppetlabs-pe_event_forwarding",


### PR DESCRIPTION
# Summary

This commit refactors metrics parsing as we no longer support the legacy metrics collected with older versions of the `puppet_metrics_collector`.

# Detailed Description
  * Updated `CHANGELOG.md`
  * Updated `metadata.json` to include puppet_metrics_collector v.8.0.0.
  * Updated `lib/puppet/application/splunk_hec.rb`.
    * Removed `parse_metrics()` function; parsing is done directly in `main`.
    * Moved `parse_legacy_metrics()` function to `lib/puppet/util/splunk_hec.rb`.
  * Maint changes to `lib/puppet/util/splunk_hec.rb`.
    * Pass `:default` (`nil`) for **file** and **line** in `Puppet.warn_once()` 

# Checklist

[X] PR title is "(Ticket|Maint) Short Description"
[X] Commit title matches PR title
