### PR TITLE
(PIE-1363) Parameter name changes and removals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       if: ${{ github.repository_owner == 'puppetlabs' }}
 
     - name: Activate Ruby 2.7
@@ -50,7 +50,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: "Activate Ruby ${{ matrix.ruby_version }}"
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/latest_testing.yml
+++ b/.github/workflows/latest_testing.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       if: ${{ github.repository_owner == 'puppetlabs' }}
 
     - name: Activate Ruby 2.7
@@ -58,7 +58,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Activate Ruby 2.7
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/lts_testing.yml
+++ b/.github/workflows/lts_testing.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       if: ${{ github.repository_owner == 'puppetlabs' }}
 
     - name: Activate Ruby 2.7
@@ -58,7 +58,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Activate Ruby 2.7
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/nightly_testing.yml
+++ b/.github/workflows/nightly_testing.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       if: ${{ github.repository_owner == 'puppetlabs' }}
 
     - name: Activate Ruby 2.7
@@ -58,7 +58,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Activate Ruby 2.7
       uses: ruby/setup-ruby@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Added
 
+- New parameters `token_events` and `url_events` can now be used to store events from `pe_event_forwarding` in a different index. [#212](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/212)
+
 - The parameter `ignore_system_cert_store` is now named `include_system_cert_store` and defaults to **false**. [#208](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/208)
 
 - Credential data provided to this module is now written to a separate configuration file utilizing the Sensitive data type to ensure redaction from Puppet logs and reports. [#204](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/204)
@@ -18,7 +20,13 @@ All notable changes to this project will be documented in this file. The format 
 
 - Add support for Puppet 8. [#200](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/200)
 
+### Removed
+
+- The deprecated `reports` parameter has been removed in favor of having the module automatically add the **splunk_hec** setting to `puppet.conf`. [#212](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/212)
+
 ### Fixed
+
+- The `collect_facts` parameter has been renamed to `facts_allowlist` to align with the `facts_blocklist` parameter. [#212](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/212)
 
 - No longer utilizing `parse_legacy_metrics` function for metrics collected with older versions of `puppet_metrics_collector`. [#211](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/211)
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Instructions assume you are using Puppet Enterprise. For Open Source Puppet inst
   * Commit the changes.
   * Run Puppet on the node group; this will cause a restart of the `pe-puppetserver` service.
 
-4. Log into the Splunk console and search `index=* sourcetype=puppet:summary`, if everything was done properly you should see the reports (and soon facts) from the systems in your Puppet environment.
+4. Log into the Splunk console and search `index=* sourcetype=puppet:summary`, if everything was done properly you should see the reports from the systems in your Puppet environment.
 
 ## Source Types
 
@@ -217,12 +217,12 @@ class profile::splunk_hec {
 
 The following parameters are utilized to configure which facts (including custom facts) you would like to send to Splunk:
 
-  * `collect_facts`
+  * `facts_allowlist`
   * `facts_blocklist` (**Optional**)
 
-To configure which facts to collect add the `collect_facts` parameter to the `splunk_hec` class and modify the array of facts presented.
+To configure which facts to collect add the `facts_allowlist` parameter to the `splunk_hec` class and modify the array of facts presented.
 
-  * To collect **all facts** available at the time of the Puppet run, add the special value `all.facts` to the `collect_facts` array.
+  * To collect **all facts** available at the time of the Puppet run, add the special value `all.facts` to the `facts_allowlist` array.
   * When collecting **all facts**, you can configure the optional parameter `facts_blocklist` with an array of facts that should not be collected.
 
 ## PE Event Forwarding

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -38,11 +38,6 @@
 
 Simple class to manage your splunk_hec connectivity
 
-* **Note** If you manage enable_reports, it will default to puppetdb,splunk_hec
-If you wish to add other reports, you can do so with the reports param
-That you can have the module automatically add the splunk_hec reports
-processor by setting reports to '', the empty string.
-
 #### Examples
 
 ##### 
@@ -71,7 +66,7 @@ The following parameters are available in the `splunk_hec` class:
       - [Parameters](#parameters)
         - [`url`](#url)
         - [`token`](#token)
-        - [`collect_facts`](#collect_facts)
+        - [`facts_allowlist`](#facts_allowlist)
         - [`enable_reports`](#enable_reports)
         - [`record_event`](#record_event)
         - [`disabled`](#disabled)
@@ -81,7 +76,6 @@ The following parameters are available in the `splunk_hec` class:
         - [`facts_terminus`](#facts_terminus)
         - [`facts_cache_terminus`](#facts_cache_terminus)
         - [`facts_blocklist`](#facts_blocklist)
-        - [`reports`](#reports)
         - [`pe_console`](#pe_console)
         - [`timeout`](#timeout)
         - [`ssl_ca`](#ssl_ca)
@@ -91,9 +85,11 @@ The following parameters are available in the `splunk_hec` class:
         - [`token_summary`](#token_summary)
         - [`token_facts`](#token_facts)
         - [`token_metrics`](#token_metrics)
+        - [`token_events`](#token_events)
         - [`url_summary`](#url_summary)
         - [`url_facts`](#url_facts)
         - [`url_metrics`](#url_metrics)
+        - [`url_events`](#url_events)
         - [`include_logs_status`](#include_logs_status)
         - [`include_logs_catalog_failure`](#include_logs_catalog_failure)
         - [`include_logs_corrective_change`](#include_logs_corrective_change)
@@ -115,7 +111,7 @@ The following parameters are available in the `splunk_hec` class:
 
 ##### <a name="-splunk_hec--url"></a>`url`
 
-Data type: `String`
+Data type: `Optional[String]`
 
 The url of the server that PE is running on
 
@@ -126,7 +122,7 @@ Data type: `Optional[String]`
 The default Splunk HEC token
 Note: The value of the token is converted to Puppet's Sensitive data type during catalog application.
 
-##### <a name="-splunk_hec--collect_facts"></a>`collect_facts`
+##### <a name="-splunk_hec--facts_allowlist"></a>`facts_allowlist`
 
 Data type: `Array`
 
@@ -203,15 +199,6 @@ Default value: `'splunk_hec'`
 Data type: `Optional[Array]`
 
 The list of facts that will not be collected in the report
-
-Default value: `undef`
-
-##### <a name="-splunk_hec--reports"></a>`reports`
-
-Data type: `Optional[String]`
-
-Can specify report processors (other than puppetdb which is default)
-Deprecated; should not use (will give warning).
 
 Default value: `undef`
 
@@ -297,6 +284,15 @@ Note: The value of the token is converted to Puppet's Sensitive data type during
 
 Default value: `undef`
 
+##### <a name="-splunk_hec--token_events"></a>`token_events`
+
+Data type: `Optional[String]`
+
+When storing events from pe_event_forwarding in a different index than the default token
+Note: The value of the token is converted to Puppet's Sensitive data type during catalog application.
+
+Default value: `undef`
+
 ##### <a name="-splunk_hec--url_summary"></a>`url_summary`
 
 Data type: `Optional[String]`
@@ -318,6 +314,14 @@ Default value: `undef`
 Data type: `Optional[String]`
 
 Similar to token_metrics; used to store metrics in a different index than the default url
+
+Default value: `undef`
+
+##### <a name="-splunk_hec--url_events"></a>`url_events`
+
+Data type: `Optional[String]`
+
+Similar to token_events; used to store events from pe_event_forwarding in a different index than the default url
 
 Default value: `undef`
 

--- a/files/hec_secrets.yaml.epp
+++ b/files/hec_secrets.yaml.epp
@@ -1,7 +1,8 @@
 <%- | Optional[Sensitive[String]] $token = undef, 
       Optional[Sensitive[String]] $token_summary = undef,
       Optional[Sensitive[String]] $token_facts = undef,
-      Optional[Sensitive[String]] $token_metrics = undef
+      Optional[Sensitive[String]] $token_metrics = undef,
+      Optional[Sensitive[String]] $token_events = undef
 | -%>
 # managed by splunk_hec module
 ---
@@ -16,4 +17,7 @@
 <% } -%>
 <% if $token_metrics { -%>
 "token_metrics" : "<%= $token_metrics %>"
+<% } -%>
+<% if $token_events { -%>
+"token_events" : "<%= $token_events %>"
 <% } -%>

--- a/lib/puppet/indirector/facts/splunk_hec.rb
+++ b/lib/puppet/indirector/facts/splunk_hec.rb
@@ -48,7 +48,6 @@ class Puppet::Node::Facts::Splunk_hec < Puppet::Node::Facts::Yaml
       ]
 
       # lets ensure user provided fact names are downcased
-      # settings['facts.allowlist'] is populated by the splunk_hec::collect_facts param
       allow_list  = (settings['facts.allowlist'].map(&:downcase) + hardcoded).uniq
       block_list  = settings['facts.blocklist'].nil? ? [] : settings['facts.blocklist'].map(&:downcase)
       # lets rescue any hardcoded facts that have been added to the blocklist

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -107,19 +107,6 @@ describe 'splunk_hec' do
         it { is_expected.to have_pe_ini_setting_resource_count(0) }
         it { is_expected.to have_pe_ini_subsetting_resource_count(1) }
       end
-
-      context "does not set 'reports' setting to $reports when $reports != undef" do
-        let(:params) do
-          p = super()
-          p['reports'] = 'foo,bar,baz'
-          p
-        end
-
-        it { is_expected.to contain_notify('reports param deprecation warning') }
-        it { is_expected.to contain_pe_ini_subsetting('enable splunk_hec').with_subsetting('splunk_hec') }
-        it { is_expected.to have_pe_ini_setting_resource_count(0) }
-        it { is_expected.to have_pe_ini_subsetting_resource_count(1) }
-      end
     end
 
     context 'disabled is set to true' do

--- a/templates/settings.yaml.epp
+++ b/templates/settings.yaml.epp
@@ -1,8 +1,10 @@
 # managed by splunk_hec module
 ---
+<% if $splunk_hec::url { -%>
 "url" : "<%= $splunk_hec::url %>"
+<% } -%>
 "facts.allowlist" :
-<% $splunk_hec::collect_facts.each |$fact| {-%>
+<% $splunk_hec::facts_allowlist.each |$fact| {-%>
         - <%= $fact %>
 <% } -%>
 <% unless $splunk_hec::facts_blocklist == undef { -%>
@@ -34,6 +36,9 @@
 <% } -%>
 <% if $splunk_hec::url_metrics { -%>
 "url_metrics" : "<%= $splunk_hec::url_metrics %>"
+<% } -%>
+<% if $splunk_hec::url_events { -%>
+"url_events" : "<%= $splunk_hec::url_events %>"
 <% } -%>
 <% if $splunk_hec::include_logs_status { -%>
 "include_logs_status" :

--- a/templates/util_splunk_hec.erb
+++ b/templates/util_splunk_hec.erb
@@ -90,7 +90,7 @@ end
 
 def submit_request(body)
   # we want users to be able to provide different tokens per sourcetype if they want
-  source_type = 'pe_event_forwarding'
+  source_type = 'events'
   token_name = "token_#{source_type}"
   http = create_http(source_type)
   token = secrets[token_name] || secrets['token'] || raise('Must provide token parameter to splunk class')


### PR DESCRIPTION
# Summary

In preparation for v2 of this module, this commit removes the deprecated `reports` parameter, renames the `collect_facts` parameter, and adds two new parameters for event forwarding credentials.

# Detailed Description

  * `manifests/init.pp`
    * Added `token_events` and `url_events` parameters for event forwarding.
    * Removed deprecated `reports` parameter.
    * Renamed `collect_facts` -> `facts_allowlist`.
  * `files/hec_secrets.yaml.epp`
    * Added event token to template.
  * `templates/settings.yaml.epp`
    * Added event url to template. 
  * `templates/util_splunk_hec.erb`
    * Renamed custom *source_type* for event forwarding.
  * `lib/puppet/indirector/facts/splunk_hec.rb` 
    * Removed comment regarding `collect_facts` parameter name.
  * `spec/classes/init_spec.rb`
    * Removed unit test against deprecated `reports` parameter.
  * Updated `README.md`
  * Updated `REFERENCE.md`
  * Updated `CHANGELOG.md`
  * **Maintenance**:
    * `manifests/init.pp` - Ensure sensitivate data is redacted from logs.


# Checklist

[X] Ensure README is updated
  [X] Any changes to existing documentation
  [X] Anything new added
[X] Unit Tests
[ ] Acceptance Tests
[X] PR title is "(Ticket|Maint) Short Description"
[X] Commit title matches PR title
