### PR TITLE
(PIE-1325) Bug fix job_id and code_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Fixed
 
+- Removed logic preventing `job_id` and `code_id` from being added to report data. [#213](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/213)
+
 - The `collect_facts` parameter has been renamed to `facts_allowlist` to align with the `facts_blocklist` parameter. [#212](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/212)
 
 - No longer utilizing `parse_legacy_metrics` function for metrics collected with older versions of `puppet_metrics_collector`. [#211](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/211)

--- a/lib/puppet/reports/splunk_hec.rb
+++ b/lib/puppet/reports/splunk_hec.rb
@@ -35,12 +35,6 @@ Puppet::Reports.register_report(:splunk_hec) do
       },
     }
 
-    # puppet 4 compatibility, code_id and job_id were added in puppet 5
-    if report_format.to_i < 7
-      job_id = nil
-      code_id = nil
-    end
-
     event = {
       'host' => host,
       'time' => epoch,
@@ -61,6 +55,7 @@ Puppet::Reports.register_report(:splunk_hec) do
         'producer' => Puppet[:certname],
         'puppet_version' => puppet_version,
         'report_format' => report_format,
+        'server_used' => server_used,
         'status' => status,
         'time' => (time + metrics['time']['total']).iso8601(3),
         'transaction_uuid' => transaction_uuid,


### PR DESCRIPTION
# Summary

This commit removes logic for supporting Puppet 4.

# Detailed Description

  * `lib/puppet/reports/splunk_hec.rb`
    * Removed `if` statement checking `report_format`.
  * Updated `CHANGELOG` 


# Checklist

[X] PR title is "(Ticket|Maint) Short Description"
[X] Commit title matches PR title
