### PR TITLE
(MAINT) Bug Fix - ship sar metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Fixed
 
+- Bug fix preventing `sar` metrics collected by `puppet_metrics_collector::system` from being shipped to Splunk. [#214](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/214)
+
 - The `collect_facts` parameter has been renamed to `facts_allowlist` to align with the `facts_blocklist` parameter. [#212](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/212)
 
 - No longer utilizing `parse_legacy_metrics` function for metrics collected with older versions of `puppet_metrics_collector`. [#211](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/211)

--- a/lib/puppet/application/splunk_hec.rb
+++ b/lib/puppet/application/splunk_hec.rb
@@ -44,7 +44,12 @@ class Puppet::Application::Splunk_hec < Puppet::Application
       content.each_key do |serv|
         event = event_template.clone
         event['host'] = name
-        event['event'] = content[serv.to_s]
+        if content[serv.to_s].is_a?(Array)
+          event['event'] = {}
+          event['event']['metrics'] = content[serv.to_s]
+        else
+          event['event'] = content[serv.to_s]
+        end
         event['event']['pe_console'] = pe_console
         event['event']['pe_service'] = serv.to_s
         Puppet.info 'Submitting metrics to Splunk'


### PR DESCRIPTION
# Summary

This commit fixes a bug that was preventing `system_cpu` metrics collected via `puppet_metrics_collector::system` from being shipped to Splunk.

# Detailed Description
  * `lib/puppet/application/splunk_hec.rb`
    * Added logic to allow for Array of sar metrics to be shipped to Splunk.
      * Previously the code assumed that the metrics would be in Hash format.
  * Updated `CHANGELOG.md`

# Checklist

[X] PR title is "(Ticket|Maint) Short Description"
[X] Commit title matches PR title
