### PR TITLE
(PIE-1643) System Metrics Formatting

### DIFF
--- a/.github/workflows/nightly_testing.yml
+++ b/.github/workflows/nightly_testing.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Setup Spec Test Matrix
       id: set-matrix
       run: |
-        echo "matrix={\"platforms\":[\"rhel-8\",\"rhel-9\",\"ubuntu-2204-lts\"]}" >> $GITHUB_OUTPUT
+        echo "matrix={\"platforms\":[\"rhel-7\",\"rhel-8\",\"rhel-9\"]}" >> $GITHUB_OUTPUT
     - name: Setup Acceptance Test Matrix
       id: build-matrix
       run: |

--- a/lib/puppet/application/splunk_hec.rb
+++ b/lib/puppet/application/splunk_hec.rb
@@ -46,7 +46,10 @@ class Puppet::Application::Splunk_hec < Puppet::Application
         event['host'] = name
         if content[serv.to_s].is_a?(Array)
           event['event'] = {}
-          event['event']['metrics'] = content[serv.to_s]
+          event['event']['metrics'] = []
+          content[serv.to_s].each do |metric|
+            event['event']['metrics'] << { metric['name'].to_s => metric['value'].to_f }
+          end
         else
           event['event'] = content[serv.to_s]
         end


### PR DESCRIPTION
# Summary

This commit changes the way that system process metrics collected with `sar` are formatted before being sent to Splunk.

# Detailed Description

Updated `lib/puppet/application/splunk_hec.rb`
  * Refactored the formatting on system metrics to set the name as the key and the value as the value. This allows for better parsing in Splunk.

**Original**:

```
name: %user
value: 0.42
```

**New**:

```
%user: 0.42
```

# Checklist

[X] PR title is "(Ticket|Maint) Short Description"
[X] Commit title matches PR title
