### PR TITLE
(PIE-1661) Release Prep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   setup_matrix:
     name: "Setup Test Matrix"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       spec_matrix: ${{ steps.get-matrix.outputs.spec_matrix }}
 
@@ -14,11 +14,11 @@ jobs:
       uses: actions/checkout@v4
       if: ${{ github.repository_owner == 'puppetlabs' }}
 
-    - name: Activate Ruby 2.7
+    - name: Activate Ruby 3.1
       uses: ruby/setup-ruby@v1
       if: ${{ github.repository_owner == 'puppetlabs' }}
       with:
-        ruby-version: "2.7"
+        ruby-version: "3.1"
         bundler-cache: true
 
     - name: Print bundle environment
@@ -39,7 +39,7 @@ jobs:
       - setup_matrix
     if: ${{ needs.setup_matrix.outputs.spec_matrix != '{}' }}
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.setup_matrix.outputs.spec_matrix)}}

--- a/.github/workflows/latest_testing.yml
+++ b/.github/workflows/latest_testing.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   setup_matrix:
     name: "Setup Test Matrix"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.acc_matrix }}
 
@@ -14,11 +14,11 @@ jobs:
       uses: actions/checkout@v4
       if: ${{ github.repository_owner == 'puppetlabs' }}
 
-    - name: Activate Ruby 2.7
+    - name: Activate Ruby 3.1
       uses: ruby/setup-ruby@v1
       if: ${{ github.repository_owner == 'puppetlabs' }}
       with:
-        ruby-version: "2.7"
+        ruby-version: "3.1"
         bundler-cache: true
 
     - name: Print bundle environment
@@ -43,6 +43,7 @@ jobs:
         --provision-exclude docker \
         --arch-exclude arm \
         --platform-exclude debian \
+        --platform-exclude redhat-8 \
         --platform-exclude sles \
         --platform-exclude ubuntu
     - name: Setup Acceptance Test Matrix
@@ -55,7 +56,7 @@ jobs:
     needs:
       - setup_matrix
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup_matrix.outputs.matrix) }}
@@ -64,10 +65,10 @@ jobs:
     - name: Checkout Source
       uses: actions/checkout@v4
 
-    - name: Activate Ruby 2.7
+    - name: Activate Ruby 3.1
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "2.7"
+        ruby-version: "3.1"
         bundler-cache: true
 
     - name: Print bundle environment

--- a/.github/workflows/lts_testing.yml
+++ b/.github/workflows/lts_testing.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   setup_matrix:
     name: "Setup Test Matrix"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
 
@@ -14,11 +14,11 @@ jobs:
       uses: actions/checkout@v4
       if: ${{ github.repository_owner == 'puppetlabs' }}
 
-    - name: Activate Ruby 2.7
+    - name: Activate Ruby 3.1
       uses: ruby/setup-ruby@v1
       if: ${{ github.repository_owner == 'puppetlabs' }}
       with:
-        ruby-version: "2.7"
+        ruby-version: "3.1"
         bundler-cache: true
 
     - name: Print bundle environment
@@ -27,31 +27,28 @@ jobs:
         echo ::group::bundler environment
          bundle env
         echo ::endgroup::
-    - name: Curl Forge for PE versions
-      id: curl_forge
-      run: |
-        echo "forge_response=$(curl https://forge.puppet.com/private/versions/pe)" >> $GITHUB_OUTPUT
-    - name: Set LTS release
-      id: lts_release
-      run: |
-        out=$(jq -c '[.[] | select(.lts == true)][0].latest | {"collection": [.]}' <<<'${{ steps.curl_forge.outputs.forge_response }}')
-        echo "lts=$out" >> $GITHUB_OUTPUT
-    - name: Setup Spec Test Matrix
-      id: set-matrix
-      run: |
-        echo "matrix={\"platforms\":[\"rhel-7\",\"rhel-8\",\"rhel-9\"]}" >> $GITHUB_OUTPUT
-    - name: Setup Acceptance Test Matrix
+          
+    - name: Build Test Matrix
       id: build-matrix
       run: |
-        out=$(echo '${{ steps.set-matrix.outputs.matrix }}' | jq -c --argjson lts '${{ steps.lts_release.outputs.lts }}' '.collection += $lts.collection') 
-        echo "matrix=$out" >> $GITHUB_OUTPUT
+        bundle exec matrix_from_metadata_v3 \
+        --provision-exclude docker \
+        --arch-exclude arm \
+        --platform-exclude debian \
+        --platform-exclude redhat-8 \
+        --platform-exclude sles \
+        --platform-exclude ubuntu \
+        --puppet-exclude 7 \
+        --puppet-exclude 8 \
+        --pe-include
+
   Integration:
-    name: "${{matrix.platforms}}, ${{matrix.collection}}"
+    name: "${{matrix.platforms.label}}, ${{matrix.collection}}"
     needs:
       - setup_matrix
     if: ${{ needs.setup_matrix.outputs.matrix != '{}' }}
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.setup_matrix.outputs.matrix)}}
@@ -60,10 +57,10 @@ jobs:
     - name: Checkout Source
       uses: actions/checkout@v4
 
-    - name: Activate Ruby 2.7
+    - name: Activate Ruby 3.1
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "2.7"
+        ruby-version: "3.1"
         bundler-cache: true
 
     - name: Print bundle environment
@@ -78,7 +75,7 @@ jobs:
         echo ::endgroup::
     - name: Provision test environment
       run: |
-        bundle exec bolt --modulepath spec/fixtures/modules plan run splunk_hec::acceptance::provision_machines using='provision_service' image='${{ matrix.platforms }}'
+        bundle exec bolt --modulepath spec/fixtures/modules plan run splunk_hec::acceptance::provision_machines using='provision_service' image='${{ matrix.platforms.image }}'
         echo ::group::=== REQUEST ===
         cat request.json || true
         echo

--- a/.github/workflows/nightly_testing.yml
+++ b/.github/workflows/nightly_testing.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   setup_matrix:
     name: "Setup Test Matrix"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
 
@@ -14,11 +14,11 @@ jobs:
       uses: actions/checkout@v4
       if: ${{ github.repository_owner == 'puppetlabs' }}
 
-    - name: Activate Ruby 2.7
+    - name: Activate Ruby 3.1
       uses: ruby/setup-ruby@v1
       if: ${{ github.repository_owner == 'puppetlabs' }}
       with:
-        ruby-version: "2.7"
+        ruby-version: "3.1"
         bundler-cache: true
 
     - name: Print bundle environment
@@ -39,7 +39,7 @@ jobs:
     - name: Setup Spec Test Matrix
       id: set-matrix
       run: |
-        echo "matrix={\"platforms\":[\"rhel-7\",\"rhel-8\",\"rhel-9\"]}" >> $GITHUB_OUTPUT
+        echo "matrix={\"platforms\":[\"rhel-7\",\"rhel-9\"]}" >> $GITHUB_OUTPUT
     - name: Setup Acceptance Test Matrix
       id: build-matrix
       run: |
@@ -51,7 +51,7 @@ jobs:
       - setup_matrix
     if: ${{ needs.setup_matrix.outputs.matrix != '{}' }}
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.setup_matrix.outputs.matrix)}}
@@ -60,10 +60,10 @@ jobs:
     - name: Checkout Source
       uses: actions/checkout@v4
 
-    - name: Activate Ruby 2.7
+    - name: Activate Ruby 3.1
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "2.7"
+        ruby-version: "3.1"
         bundler-cache: true
 
     - name: Print bundle environment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   deploy-forge:
     name: Deploy to Forge
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/release_prep.yml
+++ b/.github/workflows/release_prep.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: 3.1
 
     - name: Update Rubygems
       run: gem update --system 3.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased](https://github.com/puppetlabs/puppetlabs-splunk_hec)
 
-[Current Diff](https://github.com/puppetlabs/puppetlabs-splunk_hec/compare/v2.0.1..main)
+[Current Diff](https://github.com/puppetlabs/puppetlabs-splunk_hec/compare/v2.0.2..main)
+
+## [2.0.2](https://github.com/puppetlabs/puppetlabs-splunk_hec/tree/v2.0.2) (2025-04-23)
+
+[Full Changelog](https://github.com/puppetlabs/puppetlabs-splunk_hec/compare/v2.0.1..v2.0.2)
+
+### Fixed
+
+-  System metrics are now formatted with the metric name as the key and the metric value as the value. [#220](https://github.com/puppetlabs/puppetlabs-splunk_hec/pull/220)
 
 ## [2.0.1](https://github.com/puppetlabs/puppetlabs-splunk_hec/tree/v2.0.1) (2024-11-26)
 

--- a/manifests/v2_cleanup.pp
+++ b/manifests/v2_cleanup.pp
@@ -8,10 +8,10 @@
 #   include splunk_hec::v2_cleanup
 class splunk_hec::v2_cleanup {
   file { "${settings::confdir}/splunk_hec.yaml":
-    ensure  => absent,
+    ensure => absent,
   }
 
   file { "${settings::confdir}/splunk_hec_routes.yaml":
-    ensure  => absent,
+    ensure => absent,
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-splunk_hec",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": "puppetlabs",
   "summary": "Puppet report processor using Splunk HEC",
   "license": "Apache-2.0",

--- a/plans/acceptance/pe_server_setup.pp
+++ b/plans/acceptance/pe_server_setup.pp
@@ -21,11 +21,14 @@ plan splunk_hec::acceptance::pe_server_setup(
   #identify pe server node
   $puppet_server =  get_targets('*').filter |$n| { $n.vars['role'] == 'server' }
 
+  # extract pe version from matrix_from_metadata_v3 output
+  $pe_version = regsubst($version, '-puppet_enterprise', '')
+
   # install pe server
   run_plan(
     'deploy_pe::provision_master',
     $puppet_server,
-    'version' => $version,
+    'version' => $pe_version,
     'pe_settings' => $pe_settings
   )
 

--- a/plans/acceptance/server_setup.pp
+++ b/plans/acceptance/server_setup.pp
@@ -15,7 +15,7 @@ plan splunk_hec::acceptance::server_setup(
   $localhost = get_targets('localhost')
   run_command('sleep 15', $localhost)
 
-  if $puppet_version =~ /puppet/ {
+  if $puppet_version =~ /-nightly/ {
     run_plan(
       'splunk_hec::acceptance::oss_server_setup',
       'collection' => $puppet_version


### PR DESCRIPTION
# Summary

Release prep for v2.0.2

# Detailed Description
  * Updated `CHANGELOG.md` to include relevant changes.
  * Updated `metadata.json` with the new version number.

---

To get tests passing I found I had to also make the following changes:

Updated these files to utilize the `ubuntu-latest` action runner, the `matrix_from_metadata_v3` command when setting up the test matrix, and move to Ruby 3.1.

  * `.github/workflows/ci.yml`
  * `.github/workflows/latest_testing.yml`
  * `.github/workflows/lts_testing.yml`
  * `.github/workflows/nightly_testing.yml`
  * `.github/workflows/release.yml`
  * `.github/workflows/release_prep.yml`

Updated to reflect the change to the `matrix_from_metadata_v3` command:

  * `plans/acceptance/pe_server_setup.pp`
  * `plans/acceptance/server_setup.pp`

Lint Changes:

  * `manifests/v2_cleanup.pp`

---