### PR TITLE
(PIE-1683) Support for plans with event forwarding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       if: ${{ github.repository_owner == 'puppetlabs' }}
 
     - name: Activate Ruby 3.1
@@ -50,7 +50,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: "Activate Ruby ${{ matrix.ruby_version }}"
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/latest_testing.yml
+++ b/.github/workflows/latest_testing.yml
@@ -43,9 +43,6 @@ jobs:
         --provision-exclude docker \
         --arch-exclude arm \
         --platform-exclude debian \
-        --platform-exclude redhat-8 \
-        --platform-exclude sles \
-        --platform-exclude ubuntu
     - name: Setup Acceptance Test Matrix
       id: set-matrix
       run: |

--- a/.github/workflows/latest_testing.yml
+++ b/.github/workflows/latest_testing.yml
@@ -1,6 +1,6 @@
 name: "PE Latest Testing"
 
-on: [pull_request]
+on: [pull_request_target]
 
 jobs:
   setup_matrix:
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       if: ${{ github.repository_owner == 'puppetlabs' }}
 
     - name: Activate Ruby 3.1
@@ -43,6 +43,9 @@ jobs:
         --provision-exclude docker \
         --arch-exclude arm \
         --platform-exclude debian \
+        --platform-exclude redhat-8 \
+        --platform-exclude sles \
+        --platform-exclude 'ubuntu-(20|24).04'
     - name: Setup Acceptance Test Matrix
       id: set-matrix
       run: |
@@ -57,10 +60,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup_matrix.outputs.matrix) }}
+    env:
+      SPLUNK_CI_URL: ${{ secrets.SPLUNK_CI_URL }}
+      SPLUNK_CI_USER: ${{ secrets.SPLUNK_CI_USER }}
+      SPLUNK_CI_PASS: ${{ secrets.SPLUNK_CI_PASS }}
+      SPLUNK_CI_HEC_TOKEN: ${{ secrets.SPLUNK_CI_HEC_TOKEN }}
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Activate Ruby 3.1
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/lts_testing.yml
+++ b/.github/workflows/lts_testing.yml
@@ -36,9 +36,6 @@ jobs:
         --arch-exclude arm \
         --platform-exclude debian \
         --platform-exclude redhat-7 \
-        --platform-exclude redhat-8 \
-        --platform-exclude sles \
-        --platform-exclude ubuntu \
         --puppet-exclude 7 \
         --puppet-exclude 8 \
         --pe-include

--- a/.github/workflows/lts_testing.yml
+++ b/.github/workflows/lts_testing.yml
@@ -1,6 +1,6 @@
 name: "PE LTS Testing"
 
-on: [pull_request]
+on: [pull_request_target]
 
 jobs:
   setup_matrix:
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       if: ${{ github.repository_owner == 'puppetlabs' }}
 
     - name: Activate Ruby 3.1
@@ -35,7 +35,9 @@ jobs:
         --provision-exclude docker \
         --arch-exclude arm \
         --platform-exclude debian \
-        --platform-exclude redhat-7 \
+        --platform-exclude redhat-8 \
+        --platform-exclude sles \
+        --platform-exclude 'ubuntu-(20|24).04' \
         --puppet-exclude 7 \
         --puppet-exclude 8 \
         --pe-include
@@ -50,10 +52,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.setup_matrix.outputs.matrix)}}
+    env:
+      SPLUNK_CI_URL: ${{ secrets.SPLUNK_CI_URL }}
+      SPLUNK_CI_USER: ${{ secrets.SPLUNK_CI_USER }}
+      SPLUNK_CI_PASS: ${{ secrets.SPLUNK_CI_PASS }}
+      SPLUNK_CI_HEC_TOKEN: ${{ secrets.SPLUNK_CI_HEC_TOKEN }}
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Activate Ruby 3.1
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/nightly_testing.yml
+++ b/.github/workflows/nightly_testing.yml
@@ -1,6 +1,6 @@
 name: "Puppet Server Nightly Testing"
 
-on: [pull_request]
+on: [pull_request_target]
 
 jobs:
   setup_matrix:
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       if: ${{ github.repository_owner == 'puppetlabs' }}
 
     - name: Activate Ruby 3.1
@@ -32,7 +32,11 @@ jobs:
       run: |
         bundle exec matrix_from_metadata_v3 \
         --provision-exclude docker \
-        --arch-exclude arm
+        --arch-exclude arm \
+        --platform-exclude almalinux \
+        --platform-exclude rocky \
+        --platform-exclude sles \
+        --platform-exclude 'ubuntu-(20|24).04'
   Integration:
     name: "${{matrix.platforms.label}}, ${{matrix.collection}}"
     needs:
@@ -43,10 +47,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.setup_matrix.outputs.matrix)}}
-
+    env:
+      SPLUNK_CI_URL: ${{ secrets.SPLUNK_CI_URL }}
+      SPLUNK_CI_USER: ${{ secrets.SPLUNK_CI_USER }}
+      SPLUNK_CI_PASS: ${{ secrets.SPLUNK_CI_PASS }}
+      SPLUNK_CI_HEC_TOKEN: ${{ secrets.SPLUNK_CI_HEC_TOKEN }}
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Activate Ruby 3.1
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/nightly_testing.yml
+++ b/.github/workflows/nightly_testing.yml
@@ -7,7 +7,7 @@ jobs:
     name: "Setup Test Matrix"
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.build-matrix.outputs.matrix }}
+      matrix: ${{ steps.get-matrix.outputs.matrix }}
 
     steps:
     - name: Checkout Source
@@ -30,23 +30,11 @@ jobs:
     - name: Get Test Matrix
       id: get-matrix
       run: |
-        bundle exec matrix_from_metadata_v3
-    - name: Set nightly releases
-      id: nightly_release
-      run: |
-        out=$(echo '${{ steps.get-matrix.outputs.matrix }}' | jq -c '.collection')
-        echo "latest=$out" >> $GITHUB_OUTPUT
-    - name: Setup Spec Test Matrix
-      id: set-matrix
-      run: |
-        echo "matrix={\"platforms\":[\"rhel-7\",\"rhel-9\"]}" >> $GITHUB_OUTPUT
-    - name: Setup Acceptance Test Matrix
-      id: build-matrix
-      run: |
-        out=$(echo '${{ steps.set-matrix.outputs.matrix }}' | jq -c --argjson nightly '${{ steps.nightly_release.outputs.latest }}' '.collection += $nightly') 
-        echo "matrix=$out" >> $GITHUB_OUTPUT
+        bundle exec matrix_from_metadata_v3 \
+        --provision-exclude docker \
+        --arch-exclude arm
   Integration:
-    name: "${{matrix.platforms}}, ${{matrix.collection}}"
+    name: "${{matrix.platforms.label}}, ${{matrix.collection}}"
     needs:
       - setup_matrix
     if: ${{ needs.setup_matrix.outputs.matrix != '{}' }}
@@ -78,7 +66,7 @@ jobs:
         echo ::endgroup::
     - name: Provision test environment
       run: |
-        bundle exec bolt --modulepath spec/fixtures/modules plan run splunk_hec::acceptance::provision_machines using='provision_service' image='${{ matrix.platforms }}'
+        bundle exec bolt --modulepath spec/fixtures/modules plan run splunk_hec::acceptance::provision_machines using='provision_service' image='${{ matrix.platforms.image }}'
         echo ::group::=== REQUEST ===
         cat request.json || true
         echo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
           clean: true

--- a/.github/workflows/release_prep.yml
+++ b/.github/workflows/release_prep.yml
@@ -23,7 +23,7 @@ jobs:
       run: gem update --system 3.1.0
 
     - name: Clone repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
       with:
         ref: ${{ env.GITHUB_BRANCH }}
         # Needed to fetch all the tags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project will be documented in this file. The format 
 
 [Current Diff](https://github.com/puppetlabs/puppetlabs-splunk_hec/compare/v2.1.0..main)
 
+### Added
+
+- Added support for the `orchestrator_plan` event type from the **puppetlabs-pe_event_forwarding** module.
+  - Added `orchestrator_plan` to index mappings in util_splunk_hec template.
+  - New PE Event Forwarding filter `orchestrator_plan_data_filter` to allow filtering orchestrator plan event payloads.
+  - Module dependency updated to ensure `pe_event_forwarding` v2.3.0+ is installed.
+
+### Removed
+
+- Removed support for Debian platform and EOL operating system versions.
+- Removed support for Puppet 6.
+
 ## [2.1.0](https://github.com/puppetlabs/puppetlabs-splunk_hec/tree/v2.1.0) (2025-06-03)
 
 [Full Changelog](https://github.com/puppetlabs/puppetlabs-splunk_hec/compare/v2.0.1..v2.1.0)

--- a/README.md
+++ b/README.md
@@ -231,12 +231,13 @@ PE Customers can install the [`puppetlabs-pe_event_forwarding`](https://forge.pu
 1. See the documenation for [`puppetlabs-pe_event_forwarding`](https://forge.puppet.com/modules/puppetlabs/pe_event_forwarding) for details on installing and configuring that module. That module will need to be installed and configured before moving on to the next step.
 2. Set the `events_reporting_enabled` parameter to `true`.
 
-By default the `event_types` parameter is configured to send all event types. You can choose which event types to send by setting this parameter to one or more of `orchestrator`, `rbac`, `classifier`, `pe-console`, or `code-manager`.
+By default the `event_types` parameter is configured to send all event types. You can choose which event types to send by setting this parameter to one or more of `orchestrator`, `orchestrator_plan`, `rbac`, `classifier`, `pe-console`, or `code-manager`.
 
 ### Filtering Event Data
 
 To filter the event data, one can set the following parameters:
 * `orchestrator_data_filter`
+* `orchestrator_plan_data_filter`
 * `rbac_data_filter`
 * `classifier_data_filter`
 * `pe_console_data_filter`

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -98,6 +98,7 @@ The following parameters are available in the `splunk_hec` class:
         - [`summary_resources_format`](#summary_resources_format)
         - [`event_types`](#event_types)
         - [`orchestrator_data_filter`](#orchestrator_data_filter)
+        - [`orchestrator_plan_data_filter`](#orchestrator_plan_data_filter)
         - [`rbac_data_filter`](#rbac_data_filter)
         - [`classifier_data_filter`](#classifier_data_filter)
         - [`pe_console_data_filter`](#pe_console_data_filter)
@@ -385,15 +386,23 @@ Default value: `'hash'`
 Data type: `Array`
 
 Determines which events should be forwarded to Splunk
-Allowed values are: 'orchestrator','rbac','classifier','pe-console','code-manager'
+Allowed values are: 'orchestrator','orchestrator_plan','rbac','classifier','pe-console','code-manager'
 
-Default value: `['orchestrator','rbac','classifier','pe-console','code-manager']`
+Default value: `['orchestrator','orchestrator_plan','rbac','classifier','pe-console','code-manager']`
 
 ##### <a name="-splunk_hec--orchestrator_data_filter"></a>`orchestrator_data_filter`
 
 Data type: `Optional[Array]`
 
-Filters the jobs event data
+Filters the orchestrator jobs event data
+
+Default value: `undef`
+
+##### <a name="-splunk_hec--orchestrator_plan_data_filter"></a>`orchestrator_plan_data_filter`
+
+Data type: `Optional[Array]`
+
+Filters the orchestrator plans event data
 
 Default value: `undef`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -88,9 +88,11 @@
 #   Allowed values are: 'hash', 'array'
 # @param [Array] event_types
 #   Determines which events should be forwarded to Splunk
-#   Allowed values are: 'orchestrator','rbac','classifier','pe-console','code-manager'
+#   Allowed values are: 'orchestrator','orchestrator_plan','rbac','classifier','pe-console','code-manager'
 # @param [Optional[Array]] orchestrator_data_filter
-#   Filters the jobs event data
+#   Filters the orchestrator jobs event data
+# @param [Optional[Array]] orchestrator_plan_data_filter
+#   Filters the orchestrator plans event data
 # @param [Optional[Array]] rbac_data_filter
 #   Filters the rbac event data
 # @param [Optional[Array]] classifier_data_filter
@@ -132,8 +134,9 @@ class splunk_hec (
   Optional[Array] $include_resources_status              = undef,
   Boolean $include_resources_corrective_change           = false,
   String $summary_resources_format                       = 'hash',
-  Array $event_types                                     = ['orchestrator','rbac','classifier','pe-console','code-manager'],
+  Array $event_types                                     = ['orchestrator','orchestrator_plan','rbac','classifier','pe-console','code-manager'],
   Optional[Array] $orchestrator_data_filter              = undef,
+  Optional[Array] $orchestrator_plan_data_filter         = undef,
   Optional[Array] $rbac_data_filter                      = undef,
   Optional[Array] $classifier_data_filter                = undef,
   Optional[Array] $pe_console_data_filter                = undef,

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs-pe_event_forwarding",
-      "version_requirement": ">= 2.3.0 < 3.0.0"
+      "version_requirement": ">= 2.0.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -47,7 +47,7 @@
       ]
     },
     {
-      "operatingsystem": "RockyLinux",
+      "operatingsystem": "Rocky",
       "operatingsystemrelease": [
         "8",
         "9"
@@ -56,7 +56,6 @@
     {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
-        "12",
         "15"
       ]
     },
@@ -72,7 +71,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 7.8.0 < 9.0.0"
+      "version_requirement": ">= 8.2.0 < 9.0.0"
     }
   ],
   "pdk-version": "3.4.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-splunk_hec",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "author": "puppetlabs",
   "summary": "Puppet report processor using Splunk HEC",
   "license": "Apache-2.0",
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs-pe_event_forwarding",
-      "version_requirement": ">= 1.1.0 < 3.0.0"
+      "version_requirement": ">= 2.3.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -28,30 +28,22 @@
     {
       "operatingsystem": "AmazonLinux",
       "operatingsystemrelease": [
-        "2"
-      ]
-    },
-    {
-      "operatingsystem": "Debian",
-      "operatingsystemrelease": [
-        "9",
-        "10",
-        "11"
+        "2",
+        "2023"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "7",
         "8"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7",
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
@@ -71,19 +63,19 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04",
         "20.04",
-        "22.04"
+        "22.04",
+        "24.04"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.16.0 < 9.0.0"
+      "version_requirement": ">= 7.8.0 < 9.0.0"
     }
   ],
-  "pdk-version": "3.3.0",
+  "pdk-version": "3.4.0",
   "template-url": "https://github.com/puppetlabs/pdk-templates#3.3.0",
   "template-ref": "tags/3.3.0-0-g5d17ec1"
 }

--- a/plans/acceptance/oss_server_setup.pp
+++ b/plans/acceptance/oss_server_setup.pp
@@ -7,7 +7,7 @@
 # @param [Optional[String]] collection
 #   puppet version collection name
 plan splunk_hec::acceptance::oss_server_setup(
-  Optional[String] $collection = 'puppet7'
+  Optional[String] $collection = 'puppetcore8'
 ) {
   # get server
   $server = get_targets('*').filter |$n| { $n.vars['role'] == 'server' }
@@ -17,6 +17,9 @@ plan splunk_hec::acceptance::oss_server_setup(
   $puppetserver_facts = facts($server[0])
   $platform = $puppetserver_facts['platform']
 
+  # transform collection name to accomodate puppet core naming convention
+  $version = regsubst($collection, '^puppet(?!core)', 'puppetcore')
+
   # machines are not yet ready at time of installing the puppetserver, so we wait 15s
   run_command('sleep 15', $localhost)
 
@@ -25,7 +28,7 @@ plan splunk_hec::acceptance::oss_server_setup(
     'provision::install_puppetserver',
     $server,
     'install and configure server',
-    { 'collection' => $collection, 'platform' => $platform }
+    { 'collection' => $version, 'platform' => $platform }
   )
 
   $os_name = $puppetserver_facts['provisioner'] ? {

--- a/plans/acceptance/pe_server_setup.pp
+++ b/plans/acceptance/pe_server_setup.pp
@@ -11,7 +11,7 @@
 # @param [Optional[Hash]] pe_settings
 #   Sets PE settings including password
 plan splunk_hec::acceptance::pe_server_setup(
-  Optional[String] $version = '2021.7.5',
+  Optional[String] $version = '2023.8.5',
   Optional[Hash] $pe_settings = { password => 'puppetlabsPi3!', configure_tuning => false }
 ) {
   # machines are not yet ready at time of installing the puppetserver, so we wait 15s

--- a/plans/acceptance/server_setup.pp
+++ b/plans/acceptance/server_setup.pp
@@ -9,7 +9,7 @@
 # @param [Optional[String]] puppet_version
 #   Sets the version of Puppet Server to install
 plan splunk_hec::acceptance::server_setup(
-  Optional[String] $puppet_version = '2021.7.5',
+  Optional[String] $puppet_version = '2023.8.5',
 ) {
   # machines are not yet ready at time of installing the puppetserver, so we wait 15s
   $localhost = get_targets('localhost')

--- a/rakelib/helpers.rake
+++ b/rakelib/helpers.rake
@@ -66,6 +66,10 @@ namespace :acceptance do
 
   desc 'Sets up the Splunk instance'
   task :setup_splunk_targets do
+    if ENV['SPLUNK_CI_URL']
+      puts 'Using persistent Splunk CI instance, skipping local setup'
+      next
+    end
     inventory_hash = LitmusHelpers.inventory_hash_from_inventory_file
     splunk_setup_target = begin
                             splunk_node

--- a/spec/acceptance/events_processor_spec.rb
+++ b/spec/acceptance/events_processor_spec.rb
@@ -25,7 +25,42 @@ describe 'Event Forwarding' do
         expect(count).to be 0
       end
 
-      it 'Successfully sends an orchestrator event to splunk' do
+      it 'Successfully sends an orchestrator task event to splunk' do
+        # ensure the indexes.yaml file is created
+        server.run_shell("#{EVENT_FORWARDING_CONFDIR}/collect_api_events.rb")
+        count = report_count(report)
+        expect(count).to be 1
+      end
+
+      it 'Sets orchestrator task event properties correctly' do
+        data   = report[0]['result']
+        event  = JSON.parse(data['_raw'])
+
+        expect(data['source']).to                     eql('http:splunk_hec_token')
+        expect(data['sourcetype']).to                 eql('puppet:jobs')
+        expect(event['options']['scope']['nodes']).to eql([host_name])
+        expect(event['options']['blah']).to           be_nil
+        expect(event['environment']['name']).to       eql('production')
+        expect(event['options']['transport']).to      be_nil
+      end
+    end
+
+    context 'with orchestrator_plan event_types set' do
+      let(:report) do
+        before_run = Time.now.utc
+        server.run_shell("LC_ALL=en_US.UTF-8 puppet plan run facts targets=#{console_host_fqdn}")
+        server.run_shell("#{EVENT_FORWARDING_CONFDIR}/collect_api_events.rb")
+        after_run = Time.now.utc
+        get_splunk_report(before_run, after_run, 'puppet:plans')
+      end
+
+      it 'does not send report on first run' do
+        server.run_shell('rm /etc/puppetlabs/pe_event_forwarding/pe_event_forwarding_plan_index.yaml', expect_failures: true)
+        count = report_count(report)
+        expect(count).to be 0
+      end
+
+      it 'Successfully sends an orchestrator plan event to splunk' do
         # ensure the indexes.yaml file is created
         server.run_shell("#{EVENT_FORWARDING_CONFDIR}/collect_api_events.rb")
         count = report_count(report)
@@ -37,7 +72,7 @@ describe 'Event Forwarding' do
         event  = JSON.parse(data['_raw'])
 
         expect(data['source']).to                     eql('http:splunk_hec_token')
-        expect(data['sourcetype']).to                 eql('puppet:jobs')
+        expect(data['sourcetype']).to                 eql('puppet:plans')
         expect(event['options']['scope']['nodes']).to eql([host_name])
         expect(event['options']['blah']).to           be_nil
         expect(event['environment']['name']).to       eql('production')

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -109,7 +109,8 @@ def setup_manifest(disabled: false, cert_store: false, ssl_ca: nil, url: nil, wi
     manifest << add_event_forwarding
     params[:events_reporting_enabled] = true
     params[:orchestrator_data_filter] = ['options.scope.nodes', 'options.scope.blah', 'environment.name']
-    params[:pe_console_data_filter]   = ['subject.name', 'subject.blah', 'events']
+    params[:orchestrator_plan_data_filter] = ['options.scope.nodes', 'options.scope.blah', 'environment.name']
+    params[:pe_console_data_filter] = ['subject.name', 'subject.blah', 'events']
   end
 
   manifest << declare(:class, :splunk_hec, params)

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -79,21 +79,25 @@ end
 
 def setup_manifest(disabled: false, cert_store: false, ssl_ca: nil, url: nil, with_event_forwarding: false)
   if url.nil?
-    # This block is for checking whether we are testing locally or on the CloudCI
-    # splunk_node.uri will work locally, but bc of the discrepancy of uri and hostname
-    # on the CloudCI, and we use localhost
-    begin
-      splunk_runner = splunk_node.uri
-    rescue
-      splunk_runner = 'localhost'
+    if ENV['SPLUNK_CI_URL'] && !ENV['SPLUNK_CI_URL'].empty?
+      url = "#{ENV['SPLUNK_CI_URL']}:8088/services/collector"
+    else
+      # This block is for checking whether we are testing locally or on the CloudCI
+      # splunk_node.uri will work locally, but bc of the discrepancy of uri and hostname
+      # on the CloudCI, and we use localhost
+      begin
+        splunk_runner = splunk_node.uri
+      rescue
+        splunk_runner = 'localhost'
+      end
+      url = "https://#{splunk_runner}:8088/services/collector"
     end
-    url = "https://#{splunk_runner}:8088/services/collector/event"
   end
 
   manifest = ''
   params = {
     url:                       url,
-    token:                     'abcd1234',
+    token:                     ENV.fetch('SPLUNK_CI_HEC_TOKEN', 'abcd1234'),
     enable_reports:            true,
     manage_routes:             true,
     facts_terminus:            'yaml',
@@ -166,16 +170,26 @@ end
 def get_splunk_report(earliest, latest, sourcetype = 'puppet:summary')
   start_time = earliest.strftime('%m/%d/%Y:%H:%M:%S')
   end_time   = (latest + 2).strftime('%m/%d/%Y:%H:%M:%S')
-  query_command = 'curl -u admin:piepiepie -k '\
-    'https://localhost:8089/services/search/v2/jobs/export -d output_mode=json '\
-    "-d search='search sourcetype=\"#{sourcetype}\" AND earliest=\"#{start_time}\" AND latest=\"#{end_time}\"'"
+  splunk_user = ENV.fetch('SPLUNK_CI_USER', 'admin')
+  splunk_pass = ENV.fetch('SPLUNK_CI_PASS', 'piepiepie')
   sleep 1
-  begin
-    splunk_runner = splunk_node
-  rescue
-    splunk_runner = TARGET_SERVER
-  end
-  response = splunk_runner.run_shell(query_command).stdout
+  response = if ENV['SPLUNK_CI_URL'] && !ENV['SPLUNK_CI_URL'].empty?
+               search_url = "#{ENV['SPLUNK_CI_URL']}:8089/services/search/v2/jobs/export"
+               query_command = "curl -u #{splunk_user}:#{splunk_pass} -k " \
+                 "#{search_url} -d output_mode=json " \
+                 "-d search='search sourcetype=\"#{sourcetype}\" AND host=\"#{host_name}\" AND earliest=\"#{start_time}\" AND latest=\"#{end_time}\"'"
+               `#{query_command}`
+             else
+               query_command = "curl -u #{splunk_user}:#{splunk_pass} -k " \
+                 'https://localhost:8089/services/search/v2/jobs/export -d output_mode=json ' \
+                 "-d search='search sourcetype=\"#{sourcetype}\" AND earliest=\"#{start_time}\" AND latest=\"#{end_time}\"'"
+               begin
+                 splunk_runner = splunk_node
+               rescue
+                 splunk_runner = TARGET_SERVER
+               end
+               splunk_runner.run_shell(query_command).stdout
+             end
   JSON.parse("[#{response.split.join(',')}]")
 end
 

--- a/templates/settings.yaml.epp
+++ b/templates/settings.yaml.epp
@@ -80,6 +80,12 @@
         - <%= $subset %>
 <% } -%>
 <% } -%>
+<% if $splunk_hec::orchestrator_plan_data_filter { -%>
+"orchestrator_plan_data_filter" :
+<% $splunk_hec::orchestrator_plan_data_filter.each |$subset| {-%>
+        - <%= $subset %>
+<% } -%>
+<% } -%>
 <% if $splunk_hec::rbac_data_filter { -%>
 "rbac_data_filter" :
 <% $splunk_hec::rbac_data_filter.each |$subset| {-%>

--- a/templates/util_splunk_hec.erb
+++ b/templates/util_splunk_hec.erb
@@ -20,11 +20,12 @@ end
 @confdir  = '/etc/puppetlabs/puppet/splunk_hec'
 
 INDICES = {
-  'orchestrator' => 'puppet:jobs',
-  'rbac'         => 'puppet:activities_rbac',
-  'classifier'   => 'puppet:activities_classifier',
-  'pe-console'   => 'puppet:activities_console',
-  'code-manager' => 'puppet:activities_code_manager'
+  'orchestrator'      => 'puppet:jobs',
+  'orchestrator_plan' => 'puppet:plans',
+  'rbac'              => 'puppet:activities_rbac',
+  'classifier'        => 'puppet:activities_classifier',
+  'pe-console'        => 'puppet:activities_console',
+  'code-manager'      => 'puppet:activities_code_manager'
 }
 
 @settings_file = "#{@confdir}/settings.yaml"


### PR DESCRIPTION
# Summary

This commit adds support for sending Puppet Plan event data collected with the `pe_event_forwarding` module to Splunk.

# Detailed Description

* `manifests/init.pp`
  * Added **orchestrator_plan** to `event_types`
  * Added `$orchestrator_plan_data_filter` parameter

* `templates/settings.yaml.epp`
  * Added `orchestrator_plan_data_filter`

* `templates/util_splunk_hec.erb`
  * Added orchestrator_plan → puppet:plans mapping in INDICES

* `spec/spec_helper_acceptance_local.rb`
  * Ensure acceptance-run parameters set `orchestrator_plan_data_filter` when event forwarding is enabled

* `spec/acceptance/events_processor_spec.rb `
  * Added coverage for plan data

* `README.md`
  * Updated the event filtering section to include `orchestrator_plan_data_filter`

* `CHANGELOG.md`
  * Documented changes

# Checklist

[X] Ensure README is updated
  [X] Any changes to existing documentation
  [X] Anything new added
[X] Unit Tests
[X] Acceptance Tests
[X] PR title is "(Ticket|Maint) Short Description"
[X] Commit title matches PR title
