### PR TITLE
(PIE-1683) Support for plans with event forwarding

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,10 +3,10 @@ fixtures:
   forge_modules:
     ruby_task_helper:
       repo: "puppetlabs/ruby_task_helper"
-      ref: "0.5.1"
+      ref: "1.0.0"
     inifile:
       repo: "puppetlabs/inifile"
-      ref: "4.2.0"
+      ref: "6.1.0"
   repositories:
     stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib'
     translate: 'https://github.com/puppetlabs/puppetlabs-translate'
@@ -15,4 +15,3 @@ fixtures:
     provision: 'https://github.com/puppetlabs/provision'
     puppet_conf: 'https://github.com/puppetlabs/puppet_conf'
     pe_event_forwarding: 'https://github.com/puppetlabs/puppetlabs-pe_event_forwarding'
-    deploy_pe: 'https://github.com/jarretlavallee/puppet-deploy_pe'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       if: ${{ github.repository_owner == 'puppetlabs' }}
 
     - name: Activate Ruby 3.1
@@ -50,7 +50,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: "Activate Ruby ${{ matrix.ruby_version }}"
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/latest_testing.yml
+++ b/.github/workflows/latest_testing.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       if: ${{ github.repository_owner == 'puppetlabs' }}
 
     - name: Activate Ruby 3.1
@@ -45,7 +45,7 @@ jobs:
         --platform-exclude debian \
         --platform-exclude redhat-8 \
         --platform-exclude sles \
-        --platform-exclude ubuntu
+        --platform-exclude 'ubuntu-(20|24).04'
     - name: Setup Acceptance Test Matrix
       id: set-matrix
       run: |
@@ -60,10 +60,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup_matrix.outputs.matrix) }}
+    env:
+      SPLUNK_CI_URL: ${{ secrets.SPLUNK_CI_URL }}
+      SPLUNK_CI_USER: ${{ secrets.SPLUNK_CI_USER }}
+      SPLUNK_CI_PASS: ${{ secrets.SPLUNK_CI_PASS }}
+      SPLUNK_CI_HEC_TOKEN: ${{ secrets.SPLUNK_CI_HEC_TOKEN }}
+      SPLUNK_CI_HEC_CA: ${{ secrets.SPLUNK_CI_HEC_CA }}
+      SPLUNK_CI_IP: ${{ secrets.SPLUNK_CI_IP }}
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Activate Ruby 3.1
       uses: ruby/setup-ruby@v1
@@ -99,9 +108,12 @@ jobs:
         sed -e 's/password: .*/password: "[redacted]"/' < $FILE || true
         echo ::endgroup::
         echo INVENTORY_PATH=$FILE >> $GITHUB_ENV
+    - name: Configure inventory
+      run: |
+        bundle exec rake acceptance:configure_inventory
     - name: Install server
       run: |
-        bundle exec bolt --modulepath spec/fixtures/modules plan run splunk_hec::acceptance::server_setup puppet_version='${{ matrix.collection }}' -i ./$INVENTORY_PATH --stream
+        bundle exec bolt --modulepath spec/fixtures/modules plan run splunk_hec::acceptance::server_setup puppet_version='${{ matrix.collection }}' splunk_url="$SPLUNK_CI_URL" splunk_ip="$SPLUNK_CI_IP" -i ./$INVENTORY_PATH --stream
     - name: Install module
       run: |
         bundle exec rake 'litmus:install_module'

--- a/.github/workflows/lts_testing.yml
+++ b/.github/workflows/lts_testing.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       if: ${{ github.repository_owner == 'puppetlabs' }}
 
     - name: Activate Ruby 3.1
@@ -35,10 +35,9 @@ jobs:
         --provision-exclude docker \
         --arch-exclude arm \
         --platform-exclude debian \
-        --platform-exclude redhat-7 \
         --platform-exclude redhat-8 \
         --platform-exclude sles \
-        --platform-exclude ubuntu \
+        --platform-exclude 'ubuntu-(20|24).04' \
         --puppet-exclude 7 \
         --puppet-exclude 8 \
         --pe-include
@@ -53,10 +52,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.setup_matrix.outputs.matrix)}}
+    env:
+      SPLUNK_CI_URL: ${{ secrets.SPLUNK_CI_URL }}
+      SPLUNK_CI_USER: ${{ secrets.SPLUNK_CI_USER }}
+      SPLUNK_CI_PASS: ${{ secrets.SPLUNK_CI_PASS }}
+      SPLUNK_CI_HEC_TOKEN: ${{ secrets.SPLUNK_CI_HEC_TOKEN }}
+      SPLUNK_CI_HEC_CA: ${{ secrets.SPLUNK_CI_HEC_CA }}
+      SPLUNK_CI_IP: ${{ secrets.SPLUNK_CI_IP }}
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Activate Ruby 3.1
       uses: ruby/setup-ruby@v1
@@ -92,9 +100,12 @@ jobs:
         sed -e 's/password: .*/password: "[redacted]"/' < $FILE || true
         echo ::endgroup::
         echo INVENTORY_PATH=$FILE >> $GITHUB_ENV
+    - name: Configure inventory
+      run: |
+        bundle exec rake acceptance:configure_inventory
     - name: Install server
       run: |
-        bundle exec bolt --modulepath spec/fixtures/modules plan run splunk_hec::acceptance::server_setup puppet_version='${{ matrix.collection }}' -i ./$INVENTORY_PATH --stream
+        bundle exec bolt --modulepath spec/fixtures/modules plan run splunk_hec::acceptance::server_setup puppet_version='${{ matrix.collection }}' splunk_url="$SPLUNK_CI_URL" splunk_ip="$SPLUNK_CI_IP" -i ./$INVENTORY_PATH --stream
     - name: Install module
       run: |
         bundle exec rake 'litmus:install_module'

--- a/.github/workflows/nightly_testing.yml
+++ b/.github/workflows/nightly_testing.yml
@@ -7,11 +7,11 @@ jobs:
     name: "Setup Test Matrix"
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.build-matrix.outputs.matrix }}
+      matrix: ${{ steps.get-matrix.outputs.matrix }}
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       if: ${{ github.repository_owner == 'puppetlabs' }}
 
     - name: Activate Ruby 3.1
@@ -30,23 +30,16 @@ jobs:
     - name: Get Test Matrix
       id: get-matrix
       run: |
-        bundle exec matrix_from_metadata_v3
-    - name: Set nightly releases
-      id: nightly_release
-      run: |
-        out=$(echo '${{ steps.get-matrix.outputs.matrix }}' | jq -c '.collection')
-        echo "latest=$out" >> $GITHUB_OUTPUT
-    - name: Setup Spec Test Matrix
-      id: set-matrix
-      run: |
-        echo "matrix={\"platforms\":[\"rhel-7\",\"rhel-9\"]}" >> $GITHUB_OUTPUT
-    - name: Setup Acceptance Test Matrix
-      id: build-matrix
-      run: |
-        out=$(echo '${{ steps.set-matrix.outputs.matrix }}' | jq -c --argjson nightly '${{ steps.nightly_release.outputs.latest }}' '.collection += $nightly') 
-        echo "matrix=$out" >> $GITHUB_OUTPUT
+        bundle exec matrix_from_metadata_v3 \
+        --provision-exclude docker \
+        --arch-exclude arm \
+        --platform-exclude almalinux \
+        --platform-exclude rocky \
+        --platform-exclude sles \
+        --platform-exclude redhat-8 \
+        --platform-exclude 'ubuntu-(20|24).04'
   Integration:
-    name: "${{matrix.platforms}}, ${{matrix.collection}}"
+    name: "${{matrix.platforms.label}}, ${{matrix.collection}}"
     needs:
       - setup_matrix
     if: ${{ needs.setup_matrix.outputs.matrix != '{}' }}
@@ -55,10 +48,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.setup_matrix.outputs.matrix)}}
-
+    env:
+      SPLUNK_CI_URL: ${{ secrets.SPLUNK_CI_URL }}
+      SPLUNK_CI_USER: ${{ secrets.SPLUNK_CI_USER }}
+      SPLUNK_CI_PASS: ${{ secrets.SPLUNK_CI_PASS }}
+      SPLUNK_CI_HEC_TOKEN: ${{ secrets.SPLUNK_CI_HEC_TOKEN }}
+      SPLUNK_CI_HEC_CA: ${{ secrets.SPLUNK_CI_HEC_CA }}
+      SPLUNK_CI_IP: ${{ secrets.SPLUNK_CI_IP }}
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Activate Ruby 3.1
       uses: ruby/setup-ruby@v1
@@ -78,7 +79,7 @@ jobs:
         echo ::endgroup::
     - name: Provision test environment
       run: |
-        bundle exec bolt --modulepath spec/fixtures/modules plan run splunk_hec::acceptance::provision_machines using='provision_service' image='${{ matrix.platforms }}'
+        bundle exec bolt --modulepath spec/fixtures/modules plan run splunk_hec::acceptance::provision_machines using='provision_service' image='${{ matrix.platforms.image }}'
         echo ::group::=== REQUEST ===
         cat request.json || true
         echo
@@ -96,7 +97,7 @@ jobs:
         echo INVENTORY_PATH=$FILE >> $GITHUB_ENV
     - name: Install server
       run: |
-        bundle exec bolt --modulepath spec/fixtures/modules plan run splunk_hec::acceptance::server_setup puppet_version='${{ matrix.collection }}' -i ./$INVENTORY_PATH --stream
+        bundle exec bolt --modulepath spec/fixtures/modules plan run splunk_hec::acceptance::server_setup puppet_version='${{ matrix.collection }}' splunk_url="$SPLUNK_CI_URL" splunk_ip="$SPLUNK_CI_IP" -i ./$INVENTORY_PATH --stream
     - name: Install module
       run: |
         bundle exec rake 'litmus:install_module'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
           clean: true

--- a/.github/workflows/release_prep.yml
+++ b/.github/workflows/release_prep.yml
@@ -23,7 +23,7 @@ jobs:
       run: gem update --system 3.1.0
 
     - name: Clone repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
       with:
         ref: ${{ env.GITHUB_BRANCH }}
         # Needed to fetch all the tags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project will be documented in this file. The format 
 
 [Current Diff](https://github.com/puppetlabs/puppetlabs-splunk_hec/compare/v2.1.0..main)
 
+### Added
+
+- Added support for the `orchestrator_plan` event type from the **puppetlabs-pe_event_forwarding** module.
+  - Added `orchestrator_plan` to index mappings in util_splunk_hec template.
+  - New PE Event Forwarding filter `orchestrator_plan_data_filter` to allow filtering orchestrator plan event payloads.
+  - Module dependency updated to ensure `pe_event_forwarding` v2.3.0+ is installed.
+
+### Removed
+
+- Removed support for Debian platform and EOL operating system versions.
+- Removed support for Puppet 6.
+
 ## [2.1.0](https://github.com/puppetlabs/puppetlabs-splunk_hec/tree/v2.1.0) (2025-06-03)
 
 [Full Changelog](https://github.com/puppetlabs/puppetlabs-splunk_hec/compare/v2.0.1..v2.1.0)

--- a/README.md
+++ b/README.md
@@ -231,12 +231,13 @@ PE Customers can install the [`puppetlabs-pe_event_forwarding`](https://forge.pu
 1. See the documenation for [`puppetlabs-pe_event_forwarding`](https://forge.puppet.com/modules/puppetlabs/pe_event_forwarding) for details on installing and configuring that module. That module will need to be installed and configured before moving on to the next step.
 2. Set the `events_reporting_enabled` parameter to `true`.
 
-By default the `event_types` parameter is configured to send all event types. You can choose which event types to send by setting this parameter to one or more of `orchestrator`, `rbac`, `classifier`, `pe-console`, or `code-manager`.
+By default the `event_types` parameter is configured to send all event types. You can choose which event types to send by setting this parameter to one or more of `orchestrator`, `orchestrator_plan`, `rbac`, `classifier`, `pe-console`, or `code-manager`.
 
 ### Filtering Event Data
 
 To filter the event data, one can set the following parameters:
 * `orchestrator_data_filter`
+* `orchestrator_plan_data_filter`
 * `rbac_data_filter`
 * `classifier_data_filter`
 * `pe_console_data_filter`

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -16,7 +16,11 @@
 
 ### Functions
 
-* [`splunk_hec::secure`](#splunk_hecsecure): Custom function to mark sensitive data utilized by this module as Sensitive types in the Puppet language. Sensitive data is redacted from Pup
+* [`splunk_hec::secure`](#splunk_hec--secure): Custom function to mark sensitive data utilized by this module as Sensitive types in the Puppet language. Sensitive data is redacted from Pup
+
+### Tasks
+
+* [`install_pe`](#install_pe): Download and install Puppet Enterprise on a target node
 
 ### Plans
 
@@ -50,70 +54,52 @@ include splunk_hec
 
 The following parameters are available in the `splunk_hec` class:
 
-- [Reference](#reference)
-  - [Table of Contents](#table-of-contents)
-    - [Classes](#classes)
-      - [Public Classes](#public-classes)
-      - [Private Classes](#private-classes)
-    - [Functions](#functions)
-    - [Plans](#plans)
-      - [Public Plans](#public-plans)
-      - [Private Plans](#private-plans)
-  - [Classes](#classes-1)
-    - [`splunk_hec`](#splunk_hec)
-      - [Examples](#examples)
-        - [](#)
-      - [Parameters](#parameters)
-        - [`url`](#url)
-        - [`token`](#token)
-        - [`facts_allowlist`](#facts_allowlist)
-        - [`enable_reports`](#enable_reports)
-        - [`record_event`](#record_event)
-        - [`disabled`](#disabled)
-        - [`only_changes`](#only_changes)
-        - [`manage_routes`](#manage_routes)
-        - [`events_reporting_enabled`](#events_reporting_enabled)
-        - [`facts_terminus`](#facts_terminus)
-        - [`facts_cache_terminus`](#facts_cache_terminus)
-        - [`facts_blocklist`](#facts_blocklist)
-        - [`pe_console`](#pe_console)
-        - [`timeout`](#timeout)
-        - [`ssl_ca`](#ssl_ca)
-        - [`include_system_cert_store`](#include_system_cert_store)
-        - [`fips_crl_check`](#fips_crl_check)
-        - [`fips_verify_peer`](#fips_verify_peer)
-        - [`token_summary`](#token_summary)
-        - [`token_facts`](#token_facts)
-        - [`token_metrics`](#token_metrics)
-        - [`token_events`](#token_events)
-        - [`url_summary`](#url_summary)
-        - [`url_facts`](#url_facts)
-        - [`url_metrics`](#url_metrics)
-        - [`url_events`](#url_events)
-        - [`include_logs_status`](#include_logs_status)
-        - [`include_logs_catalog_failure`](#include_logs_catalog_failure)
-        - [`include_logs_corrective_change`](#include_logs_corrective_change)
-        - [`include_resources_status`](#include_resources_status)
-        - [`include_resources_corrective_change`](#include_resources_corrective_change)
-        - [`summary_resources_format`](#summary_resources_format)
-        - [`event_types`](#event_types)
-        - [`orchestrator_data_filter`](#orchestrator_data_filter)
-        - [`orchestrator_plan_data_filter`](#orchestrator_plan_data_filter)
-        - [`rbac_data_filter`](#rbac_data_filter)
-        - [`classifier_data_filter`](#classifier_data_filter)
-        - [`pe_console_data_filter`](#pe_console_data_filter)
-        - [`code_manager_data_filter`](#code_manager_data_filter)
-  - [Plans](#plans-1)
-    - [`splunk_hec::examples::apply_example`](#splunk_hecexamplesapply_example)
-      - [Parameters](#parameters-1)
-        - [`plan_guid`](#plan_guid)
-        - [`plan_name`](#plan_name)
-    - [`splunk_hec::examples::result_example`](#splunk_hecexamplesresult_example)
+* [`[String]`](#-splunk_hec---String-)
+* [`token`](#-splunk_hec--token)
+* [`facts_allowlist`](#-splunk_hec--facts_allowlist)
+* [`enable_reports`](#-splunk_hec--enable_reports)
+* [`record_event`](#-splunk_hec--record_event)
+* [`disabled`](#-splunk_hec--disabled)
+* [`only_changes`](#-splunk_hec--only_changes)
+* [`manage_routes`](#-splunk_hec--manage_routes)
+* [`events_reporting_enabled`](#-splunk_hec--events_reporting_enabled)
+* [`facts_terminus`](#-splunk_hec--facts_terminus)
+* [`facts_cache_terminus`](#-splunk_hec--facts_cache_terminus)
+* [`facts_blocklist`](#-splunk_hec--facts_blocklist)
+* [`pe_console`](#-splunk_hec--pe_console)
+* [`timeout`](#-splunk_hec--timeout)
+* [`ssl_ca`](#-splunk_hec--ssl_ca)
+* [`include_system_cert_store`](#-splunk_hec--include_system_cert_store)
+* [`fips_crl_check`](#-splunk_hec--fips_crl_check)
+* [`fips_verify_peer`](#-splunk_hec--fips_verify_peer)
+* [`token_summary`](#-splunk_hec--token_summary)
+* [`token_facts`](#-splunk_hec--token_facts)
+* [`token_metrics`](#-splunk_hec--token_metrics)
+* [`token_events`](#-splunk_hec--token_events)
+* [`url_summary`](#-splunk_hec--url_summary)
+* [`url_facts`](#-splunk_hec--url_facts)
+* [`url_metrics`](#-splunk_hec--url_metrics)
+* [`url_events`](#-splunk_hec--url_events)
+* [`include_logs_status`](#-splunk_hec--include_logs_status)
+* [`include_logs_catalog_failure`](#-splunk_hec--include_logs_catalog_failure)
+* [`include_logs_corrective_change`](#-splunk_hec--include_logs_corrective_change)
+* [`include_resources_status`](#-splunk_hec--include_resources_status)
+* [`include_resources_corrective_change`](#-splunk_hec--include_resources_corrective_change)
+* [`summary_resources_format`](#-splunk_hec--summary_resources_format)
+* [`event_types`](#-splunk_hec--event_types)
+* [`orchestrator_data_filter`](#-splunk_hec--orchestrator_data_filter)
+* [`orchestrator_plan_data_filter`](#-splunk_hec--orchestrator_plan_data_filter)
+* [`rbac_data_filter`](#-splunk_hec--rbac_data_filter)
+* [`classifier_data_filter`](#-splunk_hec--classifier_data_filter)
+* [`pe_console_data_filter`](#-splunk_hec--pe_console_data_filter)
+* [`code_manager_data_filter`](#-splunk_hec--code_manager_data_filter)
+* [`url`](#-splunk_hec--url)
 
-##### <a name="-splunk_hec--url"></a>`url`
+##### <a name="-splunk_hec---String-"></a>`[String]`
 
-Data type: `Optional[String]`
+Data type: `Optional`
 
+url
 The url of the server that PE is running on
 
 ##### <a name="-splunk_hec--token"></a>`token`
@@ -122,6 +108,8 @@ Data type: `Optional[String]`
 
 The default Splunk HEC token
 Note: The value of the token is converted to Puppet's Sensitive data type during catalog application.
+
+Default value: `undef`
 
 ##### <a name="-splunk_hec--facts_allowlist"></a>`facts_allowlist`
 
@@ -437,6 +425,60 @@ Data type: `Optional[Array]`
 Filters the code_manager event data
 
 Default value: `undef`
+
+##### <a name="-splunk_hec--url"></a>`url`
+
+Data type: `Optional[String]`
+
+
+
+Default value: `undef`
+
+## Functions
+
+### <a name="splunk_hec--secure"></a>`splunk_hec::secure`
+
+Type: Ruby 4.x API
+
+Custom function to mark sensitive data utilized by
+this module as Sensitive types in the Puppet language.
+Sensitive data is redacted from Puppet logs and reports.
+
+#### `splunk_hec::secure(Hash $secrets)`
+
+Custom function to mark sensitive data utilized by
+this module as Sensitive types in the Puppet language.
+Sensitive data is redacted from Puppet logs and reports.
+
+Returns: `Any`
+
+##### `secrets`
+
+Data type: `Hash`
+
+
+
+## Tasks
+
+### <a name="install_pe"></a>`install_pe`
+
+Download and install Puppet Enterprise on a target node
+
+**Supports noop?** false
+
+#### Parameters
+
+##### `url`
+
+Data type: `String[1]`
+
+The full HTTPS URL to the PE installer tarball
+
+##### `console_password`
+
+Data type: `String[1]`
+
+The PE console admin password
 
 ## Plans
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -98,6 +98,7 @@ The following parameters are available in the `splunk_hec` class:
         - [`summary_resources_format`](#summary_resources_format)
         - [`event_types`](#event_types)
         - [`orchestrator_data_filter`](#orchestrator_data_filter)
+        - [`orchestrator_plan_data_filter`](#orchestrator_plan_data_filter)
         - [`rbac_data_filter`](#rbac_data_filter)
         - [`classifier_data_filter`](#classifier_data_filter)
         - [`pe_console_data_filter`](#pe_console_data_filter)
@@ -385,15 +386,23 @@ Default value: `'hash'`
 Data type: `Array`
 
 Determines which events should be forwarded to Splunk
-Allowed values are: 'orchestrator','rbac','classifier','pe-console','code-manager'
+Allowed values are: 'orchestrator','orchestrator_plan','rbac','classifier','pe-console','code-manager'
 
-Default value: `['orchestrator','rbac','classifier','pe-console','code-manager']`
+Default value: `['orchestrator','orchestrator_plan','rbac','classifier','pe-console','code-manager']`
 
 ##### <a name="-splunk_hec--orchestrator_data_filter"></a>`orchestrator_data_filter`
 
 Data type: `Optional[Array]`
 
-Filters the jobs event data
+Filters the orchestrator jobs event data
+
+Default value: `undef`
+
+##### <a name="-splunk_hec--orchestrator_plan_data_filter"></a>`orchestrator_plan_data_filter`
+
+Data type: `Optional[Array]`
+
+Filters the orchestrator plans event data
 
 Default value: `undef`
 

--- a/lib/puppet/application/splunk_hec.rb
+++ b/lib/puppet/application/splunk_hec.rb
@@ -1,7 +1,7 @@
 require 'puppet/application'
 require File.dirname(__FILE__) + '/../util/splunk_hec.rb'
 
-# rubocop:disable Style/ClassAndModuleCamelCase
+# rubocop:disable Naming/ClassAndModuleCamelCase
 # splunk_hec.rb
 class Puppet::Application::Splunk_hec < Puppet::Application
   include Puppet::Util::Splunk_hec

--- a/lib/puppet/indirector/facts/splunk_hec.rb
+++ b/lib/puppet/indirector/facts/splunk_hec.rb
@@ -2,7 +2,7 @@ require 'puppet/indirector/facts/yaml'
 require 'puppet/util/profiler'
 require File.dirname(__FILE__) + '/../../util/splunk_hec.rb'
 
-# rubocop:disable Style/ClassAndModuleCamelCase
+# rubocop:disable Naming/ClassAndModuleCamelCase
 # splunk_hec.rb
 class Puppet::Node::Facts::Splunk_hec < Puppet::Node::Facts::Yaml
   desc "Save facts to Splunk over HEC and then to yamlcache.

--- a/lib/puppet/util/splunk_hec.rb
+++ b/lib/puppet/util/splunk_hec.rb
@@ -7,7 +7,7 @@ require 'yaml'
 require 'json'
 require 'time'
 
-# rubocop:disable Style/ClassAndModuleCamelCase
+# rubocop:disable Naming/ClassAndModuleCamelCase
 # splunk_hec.rb
 module Puppet::Util::Splunk_hec
   def settings

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -88,9 +88,11 @@
 #   Allowed values are: 'hash', 'array'
 # @param [Array] event_types
 #   Determines which events should be forwarded to Splunk
-#   Allowed values are: 'orchestrator','rbac','classifier','pe-console','code-manager'
+#   Allowed values are: 'orchestrator','orchestrator_plan','rbac','classifier','pe-console','code-manager'
 # @param [Optional[Array]] orchestrator_data_filter
-#   Filters the jobs event data
+#   Filters the orchestrator jobs event data
+# @param [Optional[Array]] orchestrator_plan_data_filter
+#   Filters the orchestrator plans event data
 # @param [Optional[Array]] rbac_data_filter
 #   Filters the rbac event data
 # @param [Optional[Array]] classifier_data_filter
@@ -132,8 +134,9 @@ class splunk_hec (
   Optional[Array] $include_resources_status              = undef,
   Boolean $include_resources_corrective_change           = false,
   String $summary_resources_format                       = 'hash',
-  Array $event_types                                     = ['orchestrator','rbac','classifier','pe-console','code-manager'],
+  Array $event_types                                     = ['orchestrator','orchestrator_plan','rbac','classifier','pe-console','code-manager'],
   Optional[Array] $orchestrator_data_filter              = undef,
+  Optional[Array] $orchestrator_plan_data_filter         = undef,
   Optional[Array] $rbac_data_filter                      = undef,
   Optional[Array] $classifier_data_filter                = undef,
   Optional[Array] $pe_console_data_filter                = undef,

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs-pe_event_forwarding",
-      "version_requirement": ">= 2.3.0 < 3.0.0"
+      "version_requirement": ">= 2.0.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -47,7 +47,7 @@
       ]
     },
     {
-      "operatingsystem": "RockyLinux",
+      "operatingsystem": "Rocky",
       "operatingsystemrelease": [
         "8",
         "9"
@@ -56,7 +56,6 @@
     {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
-        "12",
         "15"
       ]
     },
@@ -72,7 +71,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 7.8.0 < 9.0.0"
+      "version_requirement": ">= 8.2.0 < 9.0.0"
     }
   ],
   "pdk-version": "3.4.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-splunk_hec",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "author": "puppetlabs",
   "summary": "Puppet report processor using Splunk HEC",
   "license": "Apache-2.0",
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs-pe_event_forwarding",
-      "version_requirement": ">= 1.1.0 < 3.0.0"
+      "version_requirement": ">= 2.3.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -28,30 +28,22 @@
     {
       "operatingsystem": "AmazonLinux",
       "operatingsystemrelease": [
-        "2"
-      ]
-    },
-    {
-      "operatingsystem": "Debian",
-      "operatingsystemrelease": [
-        "9",
-        "10",
-        "11"
+        "2",
+        "2023"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "7",
         "8"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7",
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
@@ -71,19 +63,19 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04",
         "20.04",
-        "22.04"
+        "22.04",
+        "24.04"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.16.0 < 9.0.0"
+      "version_requirement": ">= 7.8.0 < 9.0.0"
     }
   ],
-  "pdk-version": "3.3.0",
+  "pdk-version": "3.4.0",
   "template-url": "https://github.com/puppetlabs/pdk-templates#3.3.0",
   "template-ref": "tags/3.3.0-0-g5d17ec1"
 }

--- a/plans/acceptance/oss_server_setup.pp
+++ b/plans/acceptance/oss_server_setup.pp
@@ -1,13 +1,19 @@
+# @summary Installs open source Puppet.
+# @api private
+#
 # This plan installs open source Puppet adds Puppet to the path variable, and
 # adds a puppet hosts entry. It also restarts the Puppet service and starts a
 # puppet agent run.
-# @summary Installs open source Puppet.
-# @api private
+#
+# @example
+#   splunk_hec::acceptance::oss_server_setup
 #
 # @param [Optional[String]] collection
 #   puppet version collection name
 plan splunk_hec::acceptance::oss_server_setup(
-  Optional[String] $collection = 'puppet7'
+  Optional[String] $collection = 'puppetcore8',
+  Optional[String] $splunk_url = undef,
+  Optional[String] $splunk_ip  = undef,
 ) {
   # get server
   $server = get_targets('*').filter |$n| { $n.vars['role'] == 'server' }
@@ -17,6 +23,9 @@ plan splunk_hec::acceptance::oss_server_setup(
   $puppetserver_facts = facts($server[0])
   $platform = $puppetserver_facts['platform']
 
+  # transform collection name to accomodate puppet core naming convention
+  $version = regsubst($collection, '^puppet(?!core)', 'puppetcore')
+
   # machines are not yet ready at time of installing the puppetserver, so we wait 15s
   run_command('sleep 15', $localhost)
 
@@ -25,7 +34,7 @@ plan splunk_hec::acceptance::oss_server_setup(
     'provision::install_puppetserver',
     $server,
     'install and configure server',
-    { 'collection' => $collection, 'platform' => $platform }
+    { 'collection' => $version, 'platform' => $platform }
   )
 
   $os_name = $puppetserver_facts['provisioner'] ? {
@@ -56,5 +65,12 @@ plan splunk_hec::acceptance::oss_server_setup(
 
   run_command('systemctl start puppetserver', $server, '_catch_errors' => true)
   run_command('systemctl enable puppetserver', $server, '_catch_errors' => true)
+
+  # pin the Splunk hostname in /etc/hosts so cert SAN validation works
+  if $splunk_url and $splunk_ip {
+    $splunk_host = regsubst($splunk_url, '^https?://', '')
+    run_command("echo '${splunk_ip} ${splunk_host}' >> /etc/hosts", $server)
+  }
+
   run_command('puppet agent -t', $server, '_catch_errors' => true)
 }

--- a/plans/acceptance/pe_server_setup.pp
+++ b/plans/acceptance/pe_server_setup.pp
@@ -4,39 +4,64 @@
 # Install PE Server
 #
 # @example
-#   pe_event_forwarding::acceptance::pe_server_setup
+#   splunk_hec::acceptance::pe_server_setup
 #
 # @param [Optional[String]] version
 #   Sets the version of the PE to install
 # @param [Optional[Hash]] pe_settings
 #   Sets PE settings including password
 plan splunk_hec::acceptance::pe_server_setup(
-  Optional[String] $version = '2021.7.5',
-  Optional[Hash] $pe_settings = { password => 'puppetlabsPi3!', configure_tuning => false }
+  Optional[String] $version     = '2023.8.7',
+  Optional[Hash]   $pe_settings = { password => 'puppetlabsPi3!', configure_tuning => false },
+  Optional[String] $splunk_url  = undef,
+  Optional[String] $splunk_ip   = undef,
 ) {
   # machines are not yet ready at time of installing the puppetserver, so we wait 15s
   $localhost = get_targets('localhost')
   run_command('sleep 15', $localhost)
 
-  #identify pe server node
-  $puppet_server =  get_targets('*').filter |$n| { $n.vars['role'] == 'server' }
+  # identify pe server node
+  $puppet_server = get_targets('*').filter |$n| { $n.vars['role'] == 'server' }
 
-  # extract pe version from matrix_from_metadata_v3 output
+  # extract pe version from matrix_from_metadata_v3 output (e.g. 2023.8.5-puppet_enterprise -> 2023.8.5)
   $pe_version = regsubst($version, '-puppet_enterprise', '')
 
-  # install pe server
-  run_plan(
-    'deploy_pe::provision_master',
-    $puppet_server,
-    'version' => $pe_version,
-    'pe_settings' => $pe_settings
-  )
+  # Set up each server node in parallel. Each may be a different platform so the
+  # installer URL is resolved per-target from its inventory facts.
+  $futures = $puppet_server.map |$server| {
+    background("set up PE on ${server.name}") || {
+      $platform = $server.facts['platform']
 
-  $cmd = @("CMD")
-    echo 'puppetlabsPi3!' | puppet access login -l 1y --username admin
-    puppet infrastructure tune | sed "s,\\x1B\\[[0-9;]*[a-zA-Z],,g" > /etc/puppetlabs/code/environments/production/data/common.yaml
-    puppet agent -t
-    | CMD
+      $platform_tag = case $platform {
+        /rhel-(\d+)/:          { "el-${1}-x86_64" }
+        /redhat-(\d+)/:        { "el-${1}-x86_64" }
+        /almalinux-(\d+)/:     { "el-${1}-x86_64" }
+        /rocky-linux-(\d+)/:   { "el-${1}-x86_64" }
+        /ubuntu-(\d\d)(\d\d)/: { "ubuntu-${1}.${2}-amd64" }
+        /sles-(\d+)/:          { "sles-${1}-x86_64" }
+        default: { fail("Unknown platform for PE install: ${platform}") }
+      }
 
-  run_command($cmd, $puppet_server, '_catch_errors' => true)
+      $installer_url = "https://pm.puppetlabs.com/puppet-enterprise/${pe_version}/puppet-enterprise-${pe_version}-${platform_tag}.tar.gz"
+
+      run_task(
+        'splunk_hec::install_pe',
+        $server,
+        url              => $installer_url,
+        console_password => $pe_settings['password'],
+      )
+
+      # pin the Splunk hostname in /etc/hosts so cert SAN validation works
+      if $splunk_url and $splunk_ip {
+        $splunk_host = regsubst($splunk_url, '^https?://', '')
+        run_command("echo '${splunk_ip} ${splunk_host}' >> /etc/hosts", $server)
+      }
+
+      run_command('puppet agent -t', $server, '_catch_errors' => true)
+
+      # create the RBAC token for integration testing against pe_event_forwarding
+      run_command("echo '${pe_settings['password']}' | puppet access login --username admin --lifetime 12h", $server)
+    }
+  }
+  wait($futures)
 }

--- a/plans/acceptance/provision_machines.pp
+++ b/plans/acceptance/provision_machines.pp
@@ -1,13 +1,16 @@
 # @summary Provisions machines
 # @api private
 #
+# @example
+#   splunk_hec::acceptance::provision_machines
+#
 # @param [Optional[String]] using
 #   provision service
 # @param [Optional[String]] image
 #   os image
 plan splunk_hec::acceptance::provision_machines(
   Optional[String] $using = 'abs',
-  Optional[String] $image = 'centos-7-x86_64'
+  Optional[String] $image = 'redhat-9-x86_64'
 ) {
   # provision machines, set roles
   run_task("provision::${using}", 'localhost', action => 'provision', platform => $image, vars => 'role: server')

--- a/plans/acceptance/server_setup.pp
+++ b/plans/acceptance/server_setup.pp
@@ -1,15 +1,17 @@
 # @summary Install PE Server
 # @api private
 #
-# Install PE Server
+# Install Puppet Server
 #
 # @example
-#   pe_event_forwarding::acceptance::pe_server
+#   splunk_hec::acceptance::server_setup
 #
 # @param [Optional[String]] puppet_version
 #   Sets the version of Puppet Server to install
 plan splunk_hec::acceptance::server_setup(
-  Optional[String] $puppet_version = '2021.7.5',
+  Optional[String] $puppet_version = '2023.8.5',
+  Optional[String] $splunk_url     = undef,
+  Optional[String] $splunk_ip      = undef,
 ) {
   # machines are not yet ready at time of installing the puppetserver, so we wait 15s
   $localhost = get_targets('localhost')
@@ -18,12 +20,16 @@ plan splunk_hec::acceptance::server_setup(
   if $puppet_version =~ /-nightly/ {
     run_plan(
       'splunk_hec::acceptance::oss_server_setup',
-      'collection' => $puppet_version
+      'collection'  => $puppet_version,
+      'splunk_url'  => $splunk_url,
+      'splunk_ip'   => $splunk_ip,
     )
   } else {
     run_plan(
       'splunk_hec::acceptance::pe_server_setup',
-      'version' => $puppet_version
+      'version'    => $puppet_version,
+      'splunk_url' => $splunk_url,
+      'splunk_ip'  => $splunk_ip,
     )
   }
 }

--- a/provision.yaml
+++ b/provision.yaml
@@ -1,14 +1,24 @@
 acceptance:
   provisioner: abs
   images:
-  - centos-7-x86_64
   - redhat-8-x86_64
   - redhat-9-x86_64
-  - ubuntu-2004-x86_64
+  - ubuntu-2404-x86_64
   vars: |
     role: server
+
+# One dedicated Splunk node per PE server above. Keep the count in sync with
+# the acceptance list — provision_vms pairs them by index.
+acceptance_splunk:
+  provisioner: abs
+  images:
+  - redhat-9-x86_64
+  - redhat-9-x86_64
+  - redhat-9-x86_64
+  vars: |
+    role: splunk_node
+
 fips_acceptance:
   provisioner: abs
   images:
-  - redhat-fips-7-x86_64
-  - ubuntu-2004-x86_64
+  - redhat-fips-9-x86_64

--- a/rakelib/helpers.rake
+++ b/rakelib/helpers.rake
@@ -2,10 +2,10 @@ namespace :acceptance do
   require_relative '../spec/support/acceptance/helpers'
   include TargetHelpers
 
-  desc 'Provisions the VMs. This is currently just the puppetserver'
+  desc 'Provisions the PE server VMs and a matching set of dedicated Splunk nodes'
   task :provision_vms do
     if File.exist?('spec/fixtures/litmus_inventory.yaml')
-    # Check if a puppetserver VM's already been setup
+      # Check if a puppetserver VM's already been setup
       begin
         uri = puppetserver.uri
         puts("A puppetserver VM at '#{uri}' has already been set up")
@@ -17,6 +17,15 @@ namespace :acceptance do
 
     provision_list = ENV['PROVISION_LIST'] || 'acceptance'
     Rake::Task['litmus:provision_list'].invoke(provision_list)
+
+    # Provision a matching set of dedicated Splunk nodes if a splunk list exists
+    # for this provision list (e.g. acceptance_splunk for acceptance).
+    splunk_provision_list = "#{provision_list}_splunk"
+    if YAML.safe_load(File.read('provision.yaml')).key?(splunk_provision_list)
+      Rake::Task['litmus:provision_list'].reenable
+      Rake::Task['litmus:provision_list'].invoke(splunk_provision_list)
+    end
+
     inventory_hash = inventory_hash_from_inventory_file
     begin
       # If a fips node is present, assign the correct roles to the fips node and the splunk node
@@ -24,27 +33,59 @@ namespace :acceptance do
       fips_node['vars'] = {'role' => 'server'}
       splunk_node = inventory_hash['groups'].detect {|g| g['name'] == 'ssh_nodes'}['targets'].detect {|t| !t['facts']['platform'].match(/fips/)}
       splunk_node['vars'] = {'role' => 'splunk_node'}
-    rescue => exception
+    rescue StandardError
       puts 'no fips node found.'
     end
 
-      # Remove bad username and password keys as a result of a provision module bug
-      inventory_hash['groups'].detect {|g| g['name'] == 'ssh_nodes'}['targets'].each do |target|
-        target['config']['ssh'].delete("password") if target['config']['ssh']['password'].nil?
-        target['config']['ssh'].delete("user") if target['config']['ssh']['user'].nil?
-      end
-      write_to_inventory_file(inventory_hash, 'spec/fixtures/litmus_inventory.yaml')
+    # Pair each PE server with its dedicated Splunk node by index and store the
+    # pairing in the PE server's vars so tasks and tests can look it up later.
+    ssh_nodes = inventory_hash['groups'].detect { |g| g['name'] == 'ssh_nodes' }['targets']
+    pe_servers  = ssh_nodes.select { |t| t.dig('vars', 'role') == 'server' }
+    splunk_nodes = ssh_nodes.select { |t| t.dig('vars', 'role') == 'splunk_node' }
+    pe_servers.zip(splunk_nodes).each do |pe, splunk|
+      next if splunk.nil?
+      pe['vars']['splunk_target'] = splunk['uri']
+    end
+
+    # Remove bad username and password keys as a result of a provision module bug
+    ssh_nodes.each do |target|
+      target['config']['ssh'].delete("password") if target['config']['ssh']['password'].nil?
+      target['config']['ssh'].delete("user") if target['config']['ssh']['user'].nil?
+    end
+    write_to_inventory_file(inventory_hash, 'spec/fixtures/litmus_inventory.yaml')
+    Rake::Task['acceptance:configure_inventory'].invoke
+  end
+
+  desc 'Post-process the inventory file with settings required for all bolt operations'
+  task :configure_inventory do
+    inventory_hash = inventory_hash_from_inventory_file
+    # Pin SSH encryption algorithms at the group level so all bolt operations use
+    # a known-good set. The system SSH config may specify OpenSSH cipher modifiers
+    # (e.g. ^aes128-gcm) that net-ssh does not understand, producing an empty
+    # client cipher list and causing algorithm negotiation to fail.
+    inventory_hash['groups'].each do |group|
+      group['config'] ||= {}
+      group['config']['ssh'] ||= {}
+      group['config']['ssh']['encryption-algorithms'] = %w[aes256-ctr aes192-ctr aes128-ctr]
+    end
+    write_to_inventory_file(inventory_hash, 'spec/fixtures/litmus_inventory.yaml')
   end
 
   desc 'clone puppetlabs-pe_event_forwarding module to test host'
   task :upload_pe_event_forwarding_module do
-    puppetserver.each do |target|
-      message = "Installing puppetlabs-pe_event_forwarding module on #{target.uri} !"
-      spinner = start_spinner(message)
-      target.run_shell('rm /etc/puppetlabs/code/environments/production/modules/pe_event_forwarding -rf', expect_failures: true)
-      target.bolt_upload_file('./spec/fixtures/modules/pe_event_forwarding', '/etc/puppetlabs/code/environments/production/modules')
-      stop_spinner(spinner)
+    # Uploads run in parallel so spinner output from multiple threads will interleave
+    # in the terminal. This is cosmetic only.
+    threads = puppetserver.map do |target|
+      Thread.new do
+        message = "Installing puppetlabs-pe_event_forwarding module on #{target.uri} !"
+        spinner = start_spinner(message)
+        target.run_shell('[[ -d /etc/puppetlabs/code/environments/production/modules/pe_event_forwarding ]] && rm /etc/puppetlabs/code/environments/production/modules/pe_event_forwarding -rf', expect_failures: true)
+        target.run_shell('rm -rf /etc/puppetlabs/code/environments/production/modules/pe_event_forwarding', expect_failures: true)
+        target.bolt_upload_file('./spec/fixtures/modules/pe_event_forwarding', '/etc/puppetlabs/code/environments/production/modules')
+        stop_spinner(spinner)
+      end
     end
+    threads.each(&:join)
   end
 
   desc 'Sets up PE on the server'
@@ -55,37 +96,65 @@ namespace :acceptance do
 
     config = { 'modulepath' => File.join(Dir.pwd, 'spec', 'fixtures', 'modules') }
     params = {}
-    params.merge(puppet_version: ENV['PUPPET_VERSION']) unless ENV['PUPPET_VERSION'].nil?
+    params.merge!(puppet_version: ENV['PUPPET_VERSION']) unless ENV['PUPPET_VERSION'].nil?
 
     message = "Installing Puppet Enterprise on targets in litmus_inventory.yaml !"
     install_spinner = start_spinner(message)
     bolt_result = run_plan('splunk_hec::acceptance::server_setup', params, config: config, inventory: inventory_hash.clone)
     stop_spinner(install_spinner)
     puts bolt_result['status']
+    raise "setup_pe failed:\n#{JSON.pretty_generate(bolt_result)}" if bolt_result['status'] == 'failure'
   end
 
   desc 'Sets up the Splunk instance'
   task :setup_splunk_targets do
+    if ENV['SPLUNK_CI_URL']
+      puts 'Using persistent Splunk CI instance, skipping local setup'
+      next
+    end
+
     inventory_hash = LitmusHelpers.inventory_hash_from_inventory_file
-    splunk_setup_target = begin
-                            splunk_node
-                          rescue TargetNotFoundError
-                            puppetserver
-                          end
-    splunk_setup_target.each_with_index do |splunk_target, i|    
-      message = "Starting the Splunk instance at the puppetserver (#{splunk_target.uri})"
-      splunk_spinner = start_spinner(message)
+    ssh_nodes = inventory_hash['groups'].detect { |g| g['name'] == 'ssh_nodes' }['targets']
+    pe_server_nodes = ssh_nodes.select { |t| t.dig('vars', 'role') == 'server' }
+
+    pe_server_nodes.each_with_index do |pe_node, i|
+      splunk_uri = pe_node.dig('vars', 'splunk_target')
+      unless splunk_uri
+        puts "No splunk_target paired with #{pe_node['uri']}, skipping"
+        next
+      end
+
+      pe_target     = Target.new(pe_node['uri'])
+      splunk_target = Target.new(splunk_uri)
+      splunk_hostname = splunk_uri.split(':').first
+
+      puts "Setting up Splunk Enterprise on #{splunk_uri} for PE server #{pe_node['uri']}"
       splunk_target.bolt_upload_file('./spec/support/acceptance/splunk', '/tmp/splunk')
+
+      # Generate a puppet-signed cert on the PE server for the Splunk node's hostname
+      # and upload it before running the start script, so setup_hec_ssl can configure
+      # the container without needing puppetserver installed on the Splunk node.
+      puts "Generating puppet-signed cert for #{splunk_hostname} on #{pe_node['uri']}"
+      cert_pem = pe_target.bolt_run_script(
+        'spec/support/acceptance/generate_splunk_cert.sh',
+        arguments: splunk_hostname,
+      ).stdout
+      require 'tempfile'
+      Tempfile.create(['puppet_hec', '.pem']) do |f|
+        f.write(cert_pem)
+        f.flush
+        splunk_target.bolt_upload_file(f.path, '/tmp/splunk/puppet_hec.pem')
+      end
+
+      puts "Starting Splunk on #{splunk_uri}"
       result = splunk_target.bolt_run_script('spec/support/acceptance/start_splunk_instance.sh').stdout.chomp
-      stop_spinner(splunk_spinner)
       puts result
 
       # HEC token is hard coded because it will always be the same in the splunk container
-      instance, hec_token = "#{splunk_target.uri}:8088", 'abcd1234'
+      instance  = "#{splunk_hostname}:8088"
+      hec_token = 'abcd1234'
 
-      # Update the inventory file
-      message = "Updating the inventory.yaml file with the Splunk HEC credentials for #{splunk_target.uri}"
-      inventory_spinner = start_spinner(message)
+      puts "Updating inventory with Splunk HEC credentials for #{splunk_uri}"
       splunk_group = inventory_hash['groups'].find { |g| g['name'] =~ %r{splunk} }
       unless splunk_group
         splunk_group = { 'name' => 'splunk_nodes' }
@@ -93,33 +162,36 @@ namespace :acceptance do
         splunk_group['targets'] = []
       end
       splunk_group['targets'][i] = {
-      'uri' => instance,
+        'uri' => instance,
         'config' => {
           'transport' => 'remote',
-          'remote' => {
-            'hec_token' => hec_token,
-          }
+          'remote' => { 'hec_token' => hec_token },
         },
         'facts' => {
           'platform' => 'splunk_hec',
           'provisioner' => 'docker',
-          'container_name' => 'splunk_enterprise_1'
+          'container_name' => 'splunk_enterprise_1',
         },
-        'vars' => {
-          'role' => ['splunk_instance'],
-        }
+        'vars' => { 'role' => ['splunk_instance'] },
       }
-      stop_spinner(inventory_spinner)
     end
     write_to_inventory_file(inventory_hash, 'spec/fixtures/litmus_inventory.yaml')
   end
 
   desc 'Installs the module on the puppetserver'
   task :install_module do
-    puppetserver.each do |target|
-      Rake::Task['litmus:install_module'].invoke(target.uri)
-      Rake::Task['litmus:install_module'].reenable
+    include ::BoltSpec::Run
+    include PuppetLitmus::RakeHelper
+    inventory_hash = inventory_hash_from_inventory_file
+    module_tar = Dir.glob('pkg/*.tar.gz').max_by { |f| File.mtime(f) }
+    raise "Unable to find package in 'pkg/*.tar.gz'" if module_tar.nil?
+
+    threads = puppetserver.map do |target|
+      Thread.new do
+        install_module(inventory_hash, [target.uri], module_tar)
+      end
     end
+    threads.each(&:join)
   end
 
   desc 'Runs the tests'
@@ -161,7 +233,6 @@ namespace :acceptance do
   desc 'Task to run rspec tests against multiple targets'
   task :ci_run_tests do
     include ::BoltSpec::Run
-    inventory_hash = inventory_hash_from_inventory_file
 
     # Run the tests
     config = { 'modulepath' => File.join(Dir.pwd, 'spec', 'fixtures', 'modules') }

--- a/spec/acceptance/events_processor_spec.rb
+++ b/spec/acceptance/events_processor_spec.rb
@@ -16,7 +16,7 @@ describe 'Event Forwarding' do
         server.run_shell("LC_ALL=en_US.UTF-8 puppet task run facts --nodes #{host_name}")
         server.run_shell("#{EVENT_FORWARDING_CONFDIR}/collect_api_events.rb")
         after_run = Time.now.utc
-        get_splunk_report(before_run, after_run, 'puppet:jobs')
+        get_splunk_report(before_run, after_run, 'puppet:jobs', host: host_name)
       end
 
       it 'does not send report on first run' do
@@ -36,7 +36,7 @@ describe 'Event Forwarding' do
         data   = report[0]['result']
         event  = JSON.parse(data['_raw'])
 
-        expect(data['source']).to                     eql('http:splunk_hec_token')
+        expect(data['source']).to                     eql(splunk_hec_source)
         expect(data['sourcetype']).to                 eql('puppet:jobs')
         expect(event['options']['scope']['nodes']).to eql([host_name])
         expect(event['options']['blah']).to           be_nil
@@ -51,7 +51,7 @@ describe 'Event Forwarding' do
         server.run_shell("LC_ALL=en_US.UTF-8 puppet plan run facts targets=#{console_host_fqdn}")
         server.run_shell("#{EVENT_FORWARDING_CONFDIR}/collect_api_events.rb")
         after_run = Time.now.utc
-        get_splunk_report(before_run, after_run, 'puppet:plans')
+        get_splunk_report(before_run, after_run, 'puppet:plans', host: host_name)
       end
 
       it 'does not send report on first run' do
@@ -71,11 +71,11 @@ describe 'Event Forwarding' do
         data   = report[0]['result']
         event  = JSON.parse(data['_raw'])
 
-        expect(data['source']).to                     eql('http:splunk_hec_token')
+        expect(data['source']).to                     eql(splunk_hec_source)
         expect(data['sourcetype']).to                 eql('puppet:plans')
-        expect(event['options']['scope']['nodes']).to eql([host_name])
-        expect(event['options']['blah']).to           be_nil
-        expect(event['environment']['name']).to       eql('production')
+        expect(event['options']['parameters']['targets']).to eql(host_name)
+        expect(event['options']['parameters']['blah']).to be_nil
+        expect(event['options']['environment']).to    eql('production')
         expect(event['options']['transport']).to      be_nil
       end
     end
@@ -98,7 +98,7 @@ describe 'Event Forwarding' do
         server.run_shell("LC_ALL=en_US.UTF-8 puppet task run facts --nodes #{host_name}")
         server.run_shell("#{EVENT_FORWARDING_CONFDIR}/collect_api_events.rb")
         after_run = Time.now.utc
-        get_splunk_report(before_run, after_run, 'puppet:activities_console')
+        get_splunk_report(before_run, after_run, 'puppet:activities_console', host: host_name)
       end
 
       it 'does not send report on first run' do
@@ -118,7 +118,7 @@ describe 'Event Forwarding' do
         data   = report[0]['result']
         event  = JSON.parse(data['_raw'])
 
-        expect(data['source']).to             eql('http:splunk_hec_token')
+        expect(data['source']).to             eql(splunk_hec_source)
         expect(data['sourcetype']).to         eql('puppet:activities_console')
         expect(event['events'][0]['type']).to eql('run_task')
         expect(event['subject']['blah']).to   be_nil

--- a/spec/acceptance/events_processor_spec.rb
+++ b/spec/acceptance/events_processor_spec.rb
@@ -25,7 +25,42 @@ describe 'Event Forwarding' do
         expect(count).to be 0
       end
 
-      it 'Successfully sends an orchestrator event to splunk' do
+      it 'Successfully sends an orchestrator task event to splunk' do
+        # ensure the indexes.yaml file is created
+        server.run_shell("#{EVENT_FORWARDING_CONFDIR}/collect_api_events.rb")
+        count = report_count(report)
+        expect(count).to be 1
+      end
+
+      it 'Sets orchestrator task event properties correctly' do
+        data   = report[0]['result']
+        event  = JSON.parse(data['_raw'])
+
+        expect(data['source']).to                     eql('http:splunk_hec_token')
+        expect(data['sourcetype']).to                 eql('puppet:jobs')
+        expect(event['options']['scope']['nodes']).to eql([host_name])
+        expect(event['options']['blah']).to           be_nil
+        expect(event['environment']['name']).to       eql('production')
+        expect(event['options']['transport']).to      be_nil
+      end
+    end
+
+    context 'with orchestrator_plan event_types set' do
+      let(:report) do
+        before_run = Time.now.utc
+        server.run_shell("LC_ALL=en_US.UTF-8 puppet plan run facts targets=#{console_host_fqdn}")
+        server.run_shell("#{EVENT_FORWARDING_CONFDIR}/collect_api_events.rb")
+        after_run = Time.now.utc
+        get_splunk_report(before_run, after_run, 'puppet:plans')
+      end
+
+      it 'does not send report on first run' do
+        server.run_shell('rm /etc/puppetlabs/pe_event_forwarding/pe_event_forwarding_plan_index.yaml', expect_failures: true)
+        count = report_count(report)
+        expect(count).to be 0
+      end
+
+      it 'Successfully sends an orchestrator plan event to splunk' do
         # ensure the indexes.yaml file is created
         server.run_shell("#{EVENT_FORWARDING_CONFDIR}/collect_api_events.rb")
         count = report_count(report)
@@ -37,7 +72,7 @@ describe 'Event Forwarding' do
         event  = JSON.parse(data['_raw'])
 
         expect(data['source']).to                     eql('http:splunk_hec_token')
-        expect(data['sourcetype']).to                 eql('puppet:jobs')
+        expect(data['sourcetype']).to                 eql('puppet:plans')
         expect(event['options']['scope']['nodes']).to eql([host_name])
         expect(event['options']['blah']).to           be_nil
         expect(event['environment']['name']).to       eql('production')

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -1,5 +1,6 @@
 require 'serverspec'
 require 'puppet_litmus'
+require 'base64'
 require 'support/acceptance/helpers.rb'
 
 include PuppetLitmus
@@ -17,12 +18,25 @@ RSpec.configure do |config|
   include TargetHelpers
 
   config.before(:suite) do
+    # Reset site.pp to an empty node block so stale classes from previous test
+    # runs don't interfere with the fresh setup each spec's before(:all) performs.
+    TARGET_SERVER.write_file("node default {}\n", '/etc/puppetlabs/code/environments/production/manifests/site.pp')
+
+    # Remove pe_event_forwarding configs so each run starts from a clean slate.
+    TARGET_SERVER.run_shell(
+      'rm -rf /etc/puppetlabs/pe_event_forwarding '\
+      '/opt/puppetlabs/pe_event_forwarding '\
+      '/var/log/puppetlabs/pe_event_forwarding',
+      expect_failures: true,
+    )
+
     # Stop the puppet service on the puppetserver to avoid edge-case conflicting
     # Puppet runs (one triggered by service vs one we trigger)
     shell_command = 'puppet resource service puppet ensure=stopped; '\
       'puppet module install puppetlabs-inifile --version 5.1.0'
     TARGET_SERVER.run_shell(shell_command)
     TARGET_SERVER.run_shell(DIR_TEST_COMMAND, expect_failures: true)
+    TARGET_SERVER.run_shell('rm -rf /etc/puppetlabs/code/environments/production/modules/pe_event_forwarding', expect_failures: true)
     TARGET_SERVER.bolt_upload_file(EVENT_FORWARDING_LOCAL_PATH, EVENT_FORWARDING_REMOTE_PATH)
   end
 end
@@ -77,28 +91,33 @@ def report_dir
   @report_dir ||= TARGET_SERVER.run_shell(cmd).stdout.chomp
 end
 
+def local_splunk_host
+  inventory_hash = LitmusHelpers.inventory_hash_from_inventory_file
+  all_nodes = inventory_hash['groups'].find { |g| g['name'] == 'ssh_nodes' }['targets']
+  current_node = all_nodes.find { |t| t['uri'] == ENV['TARGET_HOST'] }
+  splunk_target = current_node&.dig('vars', 'splunk_target')
+  splunk_target ? splunk_target.split(':').first : 'localhost'
+rescue StandardError
+  'localhost'
+end
+
 def setup_manifest(disabled: false, cert_store: false, ssl_ca: nil, url: nil, with_event_forwarding: false)
   if url.nil?
-    # This block is for checking whether we are testing locally or on the CloudCI
-    # splunk_node.uri will work locally, but bc of the discrepancy of uri and hostname
-    # on the CloudCI, and we use localhost
-    begin
-      splunk_runner = splunk_node.uri
-    rescue
-      splunk_runner = 'localhost'
-    end
-    url = "https://#{splunk_runner}:8088/services/collector/event"
+    url = if ENV['SPLUNK_CI_URL'] && !ENV['SPLUNK_CI_URL'].empty?
+            "#{ENV['SPLUNK_CI_URL']}:8088/services/collector"
+          else
+            "https://#{local_splunk_host}:8088/services/collector"
+          end
   end
 
   manifest = ''
   params = {
     url:                       url,
-    token:                     'abcd1234',
+    token:                     ENV.fetch('SPLUNK_CI_HEC_TOKEN', 'abcd1234'),
     enable_reports:            true,
     manage_routes:             true,
     facts_terminus:            'yaml',
     record_event:              true,
-    pe_console:                'localhost',
     disabled:                  disabled,
     include_system_cert_store: cert_store,
   }
@@ -109,7 +128,7 @@ def setup_manifest(disabled: false, cert_store: false, ssl_ca: nil, url: nil, wi
     manifest << add_event_forwarding
     params[:events_reporting_enabled] = true
     params[:orchestrator_data_filter] = ['options.scope.nodes', 'options.scope.blah', 'environment.name']
-    params[:orchestrator_plan_data_filter] = ['options.scope.nodes', 'options.scope.blah', 'environment.name']
+    params[:orchestrator_plan_data_filter] = ['options.parameters.targets', 'options.parameters.blah', 'options.environment']
     params[:pe_console_data_filter] = ['subject.name', 'subject.blah', 'events']
   end
 
@@ -137,16 +156,29 @@ def add_event_forwarding
 end
 
 def configure_ssl(cert_store: false)
+  ca_pem = if ENV['SPLUNK_CI_URL'] && !ENV['SPLUNK_CI_URL'].empty?
+             # CI mode: using the persistent Splunk instance — its CA cert must be provided.
+             ca_b64 = ENV.fetch('SPLUNK_CI_HEC_CA', nil)
+             raise 'SPLUNK_CI_HEC_CA env var not set — required for SSL tests against the CI Splunk instance' if ca_b64.nil? || ca_b64.empty?
+             Base64.decode64(ca_b64)
+           else
+             # Local mode: setup_hec_ssl in start_splunk_instance.sh signs Splunk's cert with
+             # the puppet CA, so use the puppet CA cert so splunk_hec can verify Splunk's cert.
+             TARGET_SERVER.run_shell('cat $(puppet config print localcacert)').stdout
+           end
+
+  TARGET_SERVER.run_shell('mkdir -p /etc/puppetlabs/puppet/splunk_hec')
+  TARGET_SERVER.write_file(ca_pem, '/etc/puppetlabs/puppet/splunk_hec/ca.pem')
+  TARGET_SERVER.run_shell('chmod 644 /etc/puppetlabs/puppet/splunk_hec/ca.pem')
+
+  return unless cert_store
+
   inventory_hash = LitmusHelpers.inventory_hash_from_inventory_file
   image = LitmusHelpers.facts_from_node(inventory_hash, TARGET_SERVER)
-  cmd = if cert_store
-          if image['platform'].include?('ubuntu')
-            'cp $(puppet config print localcacert) /usr/local/share/ca-certificates/splunk_hec.crt && update-ca-certificates'
-          else
-            'cp $(puppet config print localcacert) /etc/pki/ca-trust/source/anchors/splunk_hec.pem && update-ca-trust'
-          end
+  cmd = if image['platform'].include?('ubuntu')
+          'cp /etc/puppetlabs/puppet/splunk_hec/ca.pem /usr/local/share/ca-certificates/splunk_hec.crt && update-ca-certificates'
         else
-          'cp $(puppet config print localcacert) /etc/puppetlabs/puppet/splunk_hec/'
+          'cp /etc/puppetlabs/puppet/splunk_hec/ca.pem /etc/pki/ca-trust/source/anchors/splunk_hec.pem && update-ca-trust'
         end
   TARGET_SERVER.run_shell(cmd)
 end
@@ -163,20 +195,23 @@ def query_puppet_user
   service_name
 end
 
-def get_splunk_report(earliest, latest, sourcetype = 'puppet:summary')
-  start_time = earliest.strftime('%m/%d/%Y:%H:%M:%S')
-  end_time   = (latest + 2).strftime('%m/%d/%Y:%H:%M:%S')
-  query_command = 'curl -u admin:piepiepie -k '\
-    'https://localhost:8089/services/search/v2/jobs/export -d output_mode=json '\
-    "-d search='search sourcetype=\"#{sourcetype}\" AND earliest=\"#{start_time}\" AND latest=\"#{end_time}\"'"
+def get_splunk_report(earliest, latest, sourcetype = 'puppet:summary', host: host_name)
+  splunk_user = ENV.fetch('SPLUNK_CI_USER', 'admin')
+  splunk_pass = ENV.fetch('SPLUNK_CI_PASS', 'piepiepie')
+  splunk_host = (ENV['SPLUNK_CI_URL'] && !ENV['SPLUNK_CI_URL'].empty?) ? ENV['SPLUNK_CI_URL'] : "https://#{local_splunk_host}"
+  search_url  = "#{splunk_host}:8089/services/search/v2/jobs/export"
+  start_time  = earliest.strftime('%m/%d/%Y:%H:%M:%S')
+  end_time    = (latest + 2).strftime('%m/%d/%Y:%H:%M:%S')
   sleep 1
-  begin
-    splunk_runner = splunk_node
-  rescue
-    splunk_runner = TARGET_SERVER
-  end
-  response = splunk_runner.run_shell(query_command).stdout
+  query_command = "curl -u #{splunk_user}:#{splunk_pass} -k " \
+    "#{search_url} -d output_mode=json " \
+    "-d search='search sourcetype=\"#{sourcetype}\" AND host=\"#{host}\" AND earliest=\"#{start_time}\" AND latest=\"#{end_time}\"'"
+  response = TARGET_SERVER.run_shell(query_command).stdout
   JSON.parse("[#{response.split.join(',')}]")
+end
+
+def splunk_hec_source
+  (ENV['SPLUNK_CI_URL'] && !ENV['SPLUNK_CI_URL'].empty?) ? 'http:splunk_hec_ci' : 'http:splunk_hec_token'
 end
 
 def report_count(report)
@@ -194,5 +229,5 @@ def server_agent_run(manifest)
 end
 
 def console_host_fqdn
-  @console_host_fqdn ||= TARGET_SERVER.run_shell('hostname -A').stdout.strip
+  @console_host_fqdn ||= TARGET_SERVER.run_shell('hostname -f').stdout.strip
 end

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -109,7 +109,8 @@ def setup_manifest(disabled: false, cert_store: false, ssl_ca: nil, url: nil, wi
     manifest << add_event_forwarding
     params[:events_reporting_enabled] = true
     params[:orchestrator_data_filter] = ['options.scope.nodes', 'options.scope.blah', 'environment.name']
-    params[:pe_console_data_filter]   = ['subject.name', 'subject.blah', 'events']
+    params[:orchestrator_plan_data_filter] = ['options.scope.nodes', 'options.scope.blah', 'environment.name']
+    params[:pe_console_data_filter] = ['subject.name', 'subject.blah', 'events']
   end
 
   manifest << declare(:class, :splunk_hec, params)

--- a/spec/support/acceptance/generate_splunk_cert.sh
+++ b/spec/support/acceptance/generate_splunk_cert.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Generates a puppet-signed cert for the Splunk HEC endpoint and outputs the
+# combined PEM (server cert + private key + CA cert) to stdout.
+#
+# Runs on the PE server. The certname argument should be the Splunk node's
+# hostname so that SSL hostname verification passes when PE connects to it.
+#
+# Usage: generate_splunk_cert.sh <certname>
+
+set -e
+
+CERTNAME="$1"
+if [ -z "$CERTNAME" ]; then
+  echo "Usage: $0 <certname>" >&2
+  exit 1
+fi
+
+# Generate the cert — idempotent, succeeds even if the cert already exists.
+/opt/puppetlabs/bin/puppetserver ca generate --certname "$CERTNAME" >/dev/null 2>&1 || true
+
+CERTDIR=$(puppet config print certdir)
+KEYDIR=$(puppet config print privatekeydir)
+
+# Output cert + private key only. Splunk's serverCert does not need the CA cert,
+# and including it can cause Splunk's PEM parser to reject the file.
+cat "$CERTDIR/$CERTNAME.pem" "$KEYDIR/$CERTNAME.pem"

--- a/spec/support/acceptance/helpers.rb
+++ b/spec/support/acceptance/helpers.rb
@@ -1,5 +1,6 @@
 require 'puppet_litmus'
-PuppetLitmus.configure!
+# PuppetLitmus.configure! is called by spec_helper_acceptance_local.rb after requiring this file;
+# do not call it here to avoid printing 'Running tests against this machine !' twice.
 
 # The Target class and TargetHelpers module are a useful ways
 # for tests to reuse Litmus' helpers when they want to do stuff

--- a/spec/support/acceptance/splunk/defaults/default.yml
+++ b/spec/support/acceptance/splunk/defaults/default.yml
@@ -19,11 +19,4 @@ splunk:
     ssl: true
     port: 8088
     token: abcd1234
-  conf:
-    - key: inputs
-      value:
-        directory: /opt/splunk/etc/apps/splunk_httpinput/local
-        content:
-          http:
-            serverCert:
   smartstore: null

--- a/spec/support/acceptance/splunk/docker-compose.yml
+++ b/spec/support/acceptance/splunk/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     hostname: splunk_instance
     environment:
       - SPLUNK_START_ARGS=--accept-license
+      - SPLUNK_GENERAL_TERMS=--accept-sgt-current-at-splunk-com
       # The splunkbase credentials are to download and install the Puppet
       # Report Viewer from Splunkbase.
       # We could alternatively download the packaged app from a location
@@ -16,6 +17,9 @@ services:
       # default.yml is a mechanism to load splunk settings that would normally
       # be configured through the ui.
       - ./defaults:/tmp/defaults
+      # Mount our puppet-signed cert as Splunk's default server.pem so HEC uses
+      # it without needing serverCert configured anywhere.
+      - ./puppet_hec.pem:/opt/splunk/etc/auth/server.pem
     ports:
       # localhost:8000 will bring up the web interface
       - "0.0.0.0:8000:8000"

--- a/spec/support/acceptance/start_splunk_instance.sh
+++ b/spec/support/acceptance/start_splunk_instance.sh
@@ -8,11 +8,11 @@ function cleanup() {
 trap cleanup EXIT
 
 function start_splunk() {
-  id=`docker ps -q -f name=splunk-enterprise-1 -f status=running`
+  id=`docker ps -aq -f name=splunk-enterprise-1`
 
   if [ ! -z "$id" ]
   then
-    echo "Killing the current Splunk container (id = ${id}) ..."
+    echo "Removing the existing Splunk container (id = ${id}) ..."
     docker rm --force ${id}
   fi
 
@@ -29,12 +29,28 @@ function start_splunk() {
 }
 
 function yum_install_docker() {
-  yum install -y yum-utils
-  yum-config-manager \
-    --add-repo \
-    https://download.docker.com/linux/centos/docker-ce.repo
-  yum install docker-ce docker-ce-cli containerd.io docker-compose-plugin -y 
+  # Remove packages that conflict with Docker CE on RHEL 8/9
+  dnf remove -y docker docker-client docker-client-latest docker-common \
+    docker-latest docker-latest-logrotate docker-logrotate docker-engine \
+    podman runc 2>/dev/null || true
+  dnf install -y yum-utils
+  dnf config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo
+  dnf install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
   systemctl start docker
+}
+
+function apt_install_docker() {
+  # Remove packages that conflict with Docker CE on Ubuntu
+  for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do
+    apt-get remove -y $pkg 2>/dev/null || true
+  done
+  mkdir -m 0755 -p /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+    $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+  apt-get -qq update -y 1>&- 2>&-
+  apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin 1>&- 2>&-
 }
 
 function compose_starting() {
@@ -50,53 +66,29 @@ function wait_for_compose() {
   done
 }
 
-function setup_hec_ssl() {
-  echo "Setting up HEC SSL..."
-  certs=$(puppet config print certdir)
-  keys="$(puppet config print privatekeydir)"
-  s_cert='/tmp/splunk/puppet_hec.pem'
-  s_apps='/opt/splunk/etc/apps'
-  s_auth='/opt/splunk/etc/auth'
-  /opt/puppetlabs/bin/puppetserver ca generate --certname localhost &>2
-  cat "$certs/localhost.pem" "$keys/localhost.pem" "$certs/ca.pem" > $s_cert
-  docker cp $s_cert splunk-enterprise-1:$s_auth
-  docker exec -u root splunk-enterprise-1 sed -i "/Cert/c\serverCert = $s_auth/puppet_hec.pem" $s_apps/splunk_httpinput/local/inputs.conf
-}
-
-function splunk_set_minfreemb() {
-  echo "Setting Splunk custom configs..."
-  # This is a workaround for issues on Ubuntu where searches fail due to hitting default minfreemb of 5GB.
-  docker exec -u root splunk-enterprise-1 /opt/splunk/bin/splunk set minfreemb 500 -auth admin:piepiepie &>2
-  # We have to restart Splunk for the changes to get picked up.
-  docker exec -u root splunk-enterprise-1 /opt/splunk/bin/splunk restart
+function check_ssl_cert() {
+  # The cert is uploaded to /tmp/splunk/puppet_hec.pem by setup_splunk_targets
+  # before this script runs. docker-compose.yml mounts it as Splunk's default
+  # server.pem so HEC uses it without any explicit serverCert configuration.
+  # It lives under /tmp/splunk/ so the cleanup trap removes it with everything else.
+  if [ ! -f '/tmp/splunk/puppet_hec.pem' ]; then
+    echo "ERROR: /tmp/splunk/puppet_hec.pem not found — expected to be uploaded by setup_splunk_targets" >&2
+    exit 1
+  fi
+  chmod 644 /tmp/splunk/puppet_hec.pem
 }
 
 YUM=$(cat /etc/*-release | grep 'CentOS\|rhel')
 
-nodocker=$(which docker 2>&1 | grep "no docker")
-status=$?
-
-if [ ! -z "$nodocker" ]
-then
-  if [ ! -z "$YUM" ]; then
+if ! which docker &>/dev/null; then
+  if [ -n "$YUM" ]; then
     yum_install_docker
+  else
+    apt_install_docker
   fi
-else
-  # Add Docker repo for Ubuntu
-  mkdir -m 0755 -p /etc/apt/keyrings
-  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-  echo \
-  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
-  # Install Docker and Docker Compose
-  apt-get -qq update -y 1>&- 2>&-
-  apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y 1>&- 2>&-
 fi
 
-printenv
-docker system info
+check_ssl_cert
 start_splunk
 wait_for_compose
-setup_hec_ssl
-splunk_set_minfreemb
 exit 0

--- a/tasks/install_pe.json
+++ b/tasks/install_pe.json
@@ -1,0 +1,15 @@
+{
+  "description": "Download and install Puppet Enterprise on a target node",
+  "input_method": "environment",
+  "private": true,
+  "parameters": {
+    "url": {
+      "description": "The full HTTPS URL to the PE installer tarball",
+      "type": "String[1]"
+    },
+    "console_password": {
+      "description": "The PE console admin password",
+      "type": "String[1]"
+    }
+  }
+}

--- a/tasks/install_pe.sh
+++ b/tasks/install_pe.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+#
+# @summary Download and install PE
+# @api private
+#
+# Download and install Puppet Enterprise on a target node.
+#
+# @example
+#   pe_event_forwarding::acceptance::pe_server_setup
+#
+# @param [Optional[String]] version
+#   Sets the version of the PE to install
+# @param [Optional[Hash]] pe_settings
+#   Sets PE settings including password
+# Task parameters:
+#   PT_url                - Full HTTPS URL to the PE installer tarball
+#   PT_console_password   - PE console admin password
+export LANG=en_US.UTF-8
+
+_tmp_stderr="$(mktemp)"
+exec 2>>"$_tmp_stderr"
+
+fail() {
+  if [[ -s "$_tmp_stderr" ]]; then
+    echo "{ \"status\": \"error\", \"message\": \"$1\", \"stderr\": \"$(tr '\n' ' ' <"$_tmp_stderr")\" }"
+  else
+    echo "{ \"status\": \"error\", \"message\": \"$1\" }"
+  fi
+  exit "${2:-1}"
+}
+
+success() {
+  echo "$1"
+  exit 0
+}
+
+# Unpack PT_* environment variables into plain names
+for v in ${!PT_*}; do
+  declare "${v#*PT_}"="${!v}"
+done
+
+(( EUID == 0 )) || fail "This task must be run as root"
+
+[[ -n "$url" ]]              || fail "url parameter is required"
+[[ -n "$console_password" ]] || fail "console_password parameter is required"
+
+_work_dir="$(mktemp -d)"
+cd "$_work_dir" || fail "Failed to create working directory"
+
+echo "Downloading PE tarball from: $url"
+curl -Lf "$url" -o pe.tar.gz || fail "Failed to download PE tarball from: $url"
+
+echo "Extracting PE tarball..."
+tar xf pe.tar.gz || fail "Failed to extract PE tarball"
+
+pe_dir=$(find "$_work_dir" -maxdepth 1 -type d -name 'puppet-enterprise-*' | head -1)
+[[ -n "$pe_dir" ]] || fail "Could not find extracted PE directory in $_work_dir"
+
+# Write a minimal pe.conf
+cat > "$_work_dir/pe.conf" <<PECONF
+{
+  "console_admin_password": "${console_password}"
+  "puppet_enterprise::puppet_master_host": "%{::trusted.certname}"
+  "pe_install::puppet_master_dnsaltnames": ["puppet"]
+  "puppet_enterprise::profile::master::check_for_updates": false
+  "puppet_enterprise::send_analytics_data": false
+}
+PECONF
+
+echo "Starting PE installation (this may take several minutes)..."
+chmod +x "${pe_dir}/puppet-enterprise-installer"
+"${pe_dir}/puppet-enterprise-installer" -y -c "$_work_dir/pe.conf" \
+  || fail "PE installation failed"
+
+echo "Running Puppet agent (pass 1 of 2)..."
+/opt/puppetlabs/bin/puppet agent -t; true
+
+echo "Running Puppet agent (pass 2 of 2)..."
+/opt/puppetlabs/bin/puppet agent -t; true
+
+success '{ "status": "success", "message": "PE installed successfully" }'

--- a/templates/settings.yaml.epp
+++ b/templates/settings.yaml.epp
@@ -80,6 +80,12 @@
         - <%= $subset %>
 <% } -%>
 <% } -%>
+<% if $splunk_hec::orchestrator_plan_data_filter { -%>
+"orchestrator_plan_data_filter" :
+<% $splunk_hec::orchestrator_plan_data_filter.each |$subset| {-%>
+        - <%= $subset %>
+<% } -%>
+<% } -%>
 <% if $splunk_hec::rbac_data_filter { -%>
 "rbac_data_filter" :
 <% $splunk_hec::rbac_data_filter.each |$subset| {-%>

--- a/templates/util_splunk_hec.erb
+++ b/templates/util_splunk_hec.erb
@@ -20,11 +20,12 @@ end
 @confdir  = '/etc/puppetlabs/puppet/splunk_hec'
 
 INDICES = {
-  'orchestrator' => 'puppet:jobs',
-  'rbac'         => 'puppet:activities_rbac',
-  'classifier'   => 'puppet:activities_classifier',
-  'pe-console'   => 'puppet:activities_console',
-  'code-manager' => 'puppet:activities_code_manager'
+  'orchestrator'      => 'puppet:jobs',
+  'orchestrator_plan' => 'puppet:plans',
+  'rbac'              => 'puppet:activities_rbac',
+  'classifier'        => 'puppet:activities_classifier',
+  'pe-console'        => 'puppet:activities_console',
+  'code-manager'      => 'puppet:activities_code_manager'
 }
 
 @settings_file = "#{@confdir}/settings.yaml"


### PR DESCRIPTION
# Summary

This commit adds support for sending Puppet Plan event data collected with the `pe_event_forwarding` module to Splunk.

# Detailed Description

* `manifests/init.pp`
  * Added **orchestrator_plan** to `event_types`
  * Added `$orchestrator_plan_data_filter` parameter
* `templates/settings.yaml.epp`
  * Added `orchestrator_plan_data_filter`
* `templates/util_splunk_hec.erb`
  * Added orchestrator_plan → puppet:plans mapping in INDICES
* `spec/spec_helper_acceptance_local.rb`
  * Ensure acceptance-run parameters set `orchestrator_plan_data_filter` when event forwarding is enabled
* `spec/acceptance/events_processor_spec.rb `
  * Added coverage for plan data
* `README.md`
  * Updated the event filtering section to include `orchestrator_plan_data_filter`
* `CHANGELOG.md`
  * Documented changes

---

This PR also overhauls the acceptance test infrastructure to support a persistent CI Splunk instance and parallel multi-platform PE installation for local testing with VMPooler.

#### Acceptance Testing Changes

* `plans/acceptance/pe_server_setup.pp`
  * Replaced `deploy_pe::provision_master` with a custom `splunk_hec::install_pe` task that downloads and installs PE directly from `pm.puppetlabs.com`. Installations now run in parallel across multiple server targets using `background()` with platform detection to resolve the correct installer URL per target. Also adds `/etc/hosts` pinning for the persistent CI Splunk hostname.
* `plans/acceptance/oss_server_setup.pp`
  * Added `splunk_url`/`splunk_ip` parameters and `/etc/hosts` pinning to match PE server setup. Updated default collection to `puppetcore8` and added a `regsubst` to handle the `puppetcore` naming convention used by nightly builds.
* `plans/acceptance/server_setup.pp`
  * Passes `splunk_url` and `splunk_ip` through to `oss_server_setup` so nightly builds also get `/etc/hosts` pinning for the CI Splunk instance.
* `tasks/install_pe.{sh,json}`
  * New task that downloads a PE tarball from a given URL, writes a minimal `pe.conf`, runs the installer, and runs two initial puppet agent passes. Replaces the previous dependency on `deploy_pe::provision_master`.
* `templates/util_splunk_hec.erb`
  * Added `orchestrator_plan => 'puppet:plans'` to the `INDICES` map so orchestrator plan events are forwarded to Splunk with the correct sourcetype.
* `spec/acceptance/events_processor_spec.rb`
  * Updated all event forwarding Splunk queries to use `host: host_name` (the PE server FQDN) instead of `localhost` so parallel CI runs targeting the same Splunk instance don't contaminate each other's results.
* `spec/spec_helper_acceptance_local.rb`
  * `configure_ssl`: reads the Splunk CA cert from `SPLUNK_CI_HEC_CA` (base64-encoded) in CI mode; falls back to the puppet CA in local mode. Adds `chmod 644` on `ca.pem` so pe-puppet can read it.
  * `setup_manifest`: resolves the Splunk HEC URL from `SPLUNK_CI_URL` env var in CI mode or the litmus inventory in local mode. Removed hardcoded `pe_console: 'localhost'` so `splunk_hec` defaults to `$settings::report_server` (the PE server FQDN), making Splunk event `host` fields unique per node.
  * `get_splunk_report`: parameterized with a `host:` keyword argument (defaulting to `host_name`) and updated to use configurable credentials and Splunk URL from env vars.
  * `splunk_hec_source`: new helper that returns the correct Splunk HEC source name based on whether the CI or local Splunk instance is in use.
  * `local_splunk_host`: new helper that resolves the Splunk hostname from the litmus inventory for the current target.
* `rakelib/helpers.rake`
  * Updated `provision_vms` to provision a matching set of dedicated Splunk nodes alongside PE servers and pair them in the inventory. Added `configure_inventory` to pin SSH encryption algorithms for bolt compatibility. Added `setup_splunk_targets` to start local Splunk instances and write HEC credentials into the inventory.
* `.github/workflows/nightly_testing.yml`
  * Rewrote matrix generation to use `matrix_from_metadata_v3` with platform exclusions. Passed CI Splunk secrets as env vars to the integration job. Updated `actions/checkout` to v6 and pinned to the PR head SHA.

---

#### PDK Changes

* `lib/puppet/application/splunk_hec.rb`, `lib/puppet/indirector/facts/splunk_hec.rb`, `lib/puppet/util/splunk_hec.rb`
  * Fixed inline RuboCop disable comments: `Style/ClassAndModuleCamelCase` → `Naming/ClassAndModuleCamelCase`.
